### PR TITLE
[CHORE]  ResponseData와 예외 메세지 통일 기능

### DIFF
--- a/backend/src/main/java/com/tripfriend/global/dto/RsData.java
+++ b/backend/src/main/java/com/tripfriend/global/dto/RsData.java
@@ -1,0 +1,29 @@
+package com.tripfriend.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+
+@AllArgsConstructor
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RsData<T> {
+
+    @NonNull
+    private String code;
+
+    @NonNull
+    private String msg;
+
+    private T data;
+
+    public RsData(String code, String msg){
+        this(code, msg, null);
+    }
+
+    public int getStatusCode(){
+        String statusCodeStr = code.split("-")[0];
+        return Integer.parseInt(statusCodeStr);
+    }
+}

--- a/backend/src/main/java/com/tripfriend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/tripfriend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.tripfriend.global.exception;
+
+import com.tripfriend.global.dto.RsData;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /*
+        MethodArgumentNotValidException 예외 처리
+        -> 요청 데이터 검증 할 때, 유효성 검사 실패 시 발생하는 예외 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<RsData<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        // 검증 실패한 필드의 오류 메시지를 정리하여 하나의 문자열 반환
+        String message = e.getBindingResult().getFieldErrors()
+                .stream()
+                .map(fe -> fe.getField() + " : " + fe.getCode() + " : "  + fe.getDefaultMessage())
+                .sorted()
+                .collect(Collectors.joining("\n"));
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST) // 400 Bad Request
+                .body(
+                        new RsData<>(
+                                "400-1",
+                                message
+                        )
+                );
+    }
+
+    /*
+        서비스 계층에서 발생하는 예외 처리
+        예외 내부에서 정의된 HTTP 상태 코드와 코드 및 메시지를 포함한 응답 반환
+     */
+    @ExceptionHandler(ServiceException.class)
+    public ResponseEntity<RsData<Void>> ServiceExceptionHandle(ServiceException ex) {
+
+        return ResponseEntity
+                .status(ex.getStatusCode())
+                .body(
+                        new RsData<>(
+                                ex.getCode(),
+                                ex.getMsg()
+                        )
+                );
+    }
+}

--- a/backend/src/main/java/com/tripfriend/global/exception/ServiceException.java
+++ b/backend/src/main/java/com/tripfriend/global/exception/ServiceException.java
@@ -1,0 +1,27 @@
+package com.tripfriend.global.exception;
+
+import com.tripfriend.global.dto.RsData;
+
+public class ServiceException extends RuntimeException{
+
+    private RsData<?> rsData;
+
+    public ServiceException(String code, String msg){
+        super(msg);
+        rsData = new RsData<>(code, msg);
+    }
+
+    public String getCode(){
+        return rsData.getCode();
+    }
+
+    public String getMsg(){
+        return rsData.getMsg();
+    }
+
+    public int getStatusCode(){
+        return rsData.getStatusCode();
+    }
+
+}
+


### PR DESCRIPTION
- 제목 : #28 

## 🔎 작업 내용

- RsData 클래스 추가
   - 일관된 응답 형식으로 인해 통일성 증가
- ServiceException 클래스 추가
   - 일관된 예외처리 메세지로 인해 통일성 증가
- GlobalException 클래스 추가
   - Spring MVC에서 발생하는 예외들을 한 곳에서 처리하고, 일관된 응답 형식 제공

  <br/>

## ➕ 이슈 링크
- [GODAOS/feat-28 #28 ]

<br/>

<!-- closed #번호 -->
