### PR TITLE
feat(38): 리뷰 목록 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/tripfriend/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/tripfriend/domain/review/controller/ReviewController.java
@@ -67,4 +67,17 @@ public class ReviewController {
         reviewService.deleteReview(reviewId, member);
         return ResponseEntity.noContent().build();
     }
+
+    // 리뷰 목록 조회 (정렬 및 검색)
+    @GetMapping
+    public ResponseEntity<List<ReviewResponseDto>> getReviews(
+            @RequestParam(defaultValue = "newest") String sort,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Long placeId,
+            @RequestParam(required = false) Long memberId) {
+
+        List<ReviewResponseDto> reviews = reviewService.getReviews(sort, keyword, placeId, memberId);
+        return ResponseEntity.ok(reviews);
+    }
+
 }

--- a/backend/src/main/java/com/tripfriend/domain/review/dto/ReviewRequestDto.java
+++ b/backend/src/main/java/com/tripfriend/domain/review/dto/ReviewRequestDto.java
@@ -23,7 +23,6 @@ public class ReviewRequestDto {
 
     @Min(value = 1, message = "평점은 1점 이상이어야 합니다.")
     @Max(value = 5, message = "평점은 5점 이하여야 합니다.")
-    private int rating;
-
+    private double rating; // int -> double
     private Long placeId;
 }

--- a/backend/src/main/java/com/tripfriend/domain/review/dto/ReviewResponseDto.java
+++ b/backend/src/main/java/com/tripfriend/domain/review/dto/ReviewResponseDto.java
@@ -12,7 +12,7 @@ public class ReviewResponseDto {
     private Long reviewId;
     private String title;
     private String content;
-    private int rating;
+    private double rating;
     private Long memberId;
     private String memberName;
     private Long placeId;

--- a/backend/src/main/java/com/tripfriend/domain/review/entity/Review.java
+++ b/backend/src/main/java/com/tripfriend/domain/review/entity/Review.java
@@ -26,7 +26,7 @@ public class Review {
     private String content;
 
     @Column(nullable = false)
-    private int rating;
+    private double rating;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -41,7 +41,7 @@ public class Review {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
-    public Review(String title, String content, int rating, Member member, Long placeId) {
+    public Review(String title, String content, double rating, Member member, Long placeId) {
         this.title = title;
         this.content = content;
         this.rating = rating;
@@ -51,7 +51,7 @@ public class Review {
         this.updatedAt = this.createdAt;
     }
 
-    public void update(String title, String content, int rating) {
+    public void update(String title, String content, double rating) {
         this.title = title;
         this.content = content;
         this.rating = rating;

--- a/backend/src/main/java/com/tripfriend/domain/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/tripfriend/domain/review/repository/ReviewRepository.java
@@ -2,18 +2,42 @@ package com.tripfriend.domain.review.repository;
 
 import com.tripfriend.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    // 특정 장소의 리뷰 목록 최신순으로 조회
+
+    // 댓글 수를 기준으로 리뷰 정렬 (많은 순)
+    @Query("SELECT r, COUNT(c) as commentCount FROM Review r LEFT JOIN Comment c ON r.reviewId = c.review.reviewId GROUP BY r ORDER BY commentCount DESC")
+    List<Object[]> findAllOrderByCommentCountDesc();
+
+    // 평점 높은 순으로 정렬
+    List<Review> findAllByOrderByRatingDesc();
+
+    // 평점 낮은 순으로 정렬
+    List<Review> findAllByOrderByRatingAsc();
+
+    // 최신순 정렬 - 기본값
+    List<Review> findAllByOrderByCreatedAtDesc();
+
+    // 오래된순 정렬
+    List<Review> findAllByOrderByCreatedAtAsc();
+
+    // 제목으로 검색
+    List<Review> findByTitleContainingOrderByCreatedAtDesc(String keyword);
+
+    // 여행지 ID로 검색
     List<Review> findByPlaceIdOrderByCreatedAtDesc(Long placeId);
 
-    // 특정 회원이 작성한 리뷰 목록 조회
-    List<Review> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+    // 여행지 ID + 정렬 옵션 (평점 높은 순)
+    List<Review> findByPlaceIdOrderByRatingDesc(Long placeId);
 
-    // 평점이 높은 리뷰 상위 n개 조회
-    List<Review> findTop10ByOrderByRatingDesc();
+    // 여행지 ID + 정렬 옵션 (평점 낮은 순)
+    List<Review> findByPlaceIdOrderByRatingAsc(Long placeId);
+
+    // 특정 사용자의 리뷰 목록
+    List<Review> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 }

--- a/backend/src/main/java/com/tripfriend/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/tripfriend/domain/review/service/ReviewService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -95,5 +96,77 @@ public class ReviewService {
 
         // 리뷰 삭제
         reviewRepository.delete(review);
+    }
+
+    // 리뷰 목록 조회 (정렬 및 검색 기능)
+    public List<ReviewResponseDto> getReviews(String sort, String keyword, Long placeId, Long memberId) {
+        List<Review> reviews = new ArrayList<>();
+        List<ReviewResponseDto> reviewDtos = new ArrayList<>();
+
+        // 특정 회원의 리뷰만 조회
+        if (memberId != null) {
+            reviews = reviewRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+        }
+        // 특정 여행지의 리뷰만 조회
+        else if (placeId != null) {
+            if ("highest_rating".equals(sort)) {
+                reviews = reviewRepository.findByPlaceIdOrderByRatingDesc(placeId);
+            } else if ("lowest_rating".equals(sort)) {
+                reviews = reviewRepository.findByPlaceIdOrderByRatingAsc(placeId);
+            } else {
+                reviews = reviewRepository.findByPlaceIdOrderByCreatedAtDesc(placeId);
+            }
+        }
+        // 제목 검색
+        else if (keyword != null && !keyword.trim().isEmpty()) {
+            reviews = reviewRepository.findByTitleContainingOrderByCreatedAtDesc(keyword);
+        }
+        // 전체 리뷰 조회 (정렬 옵션 적용)
+        else {
+            switch (sort) {
+                case "comments":
+                    List<Object[]> commentCountResult = reviewRepository.findAllOrderByCommentCountDesc();
+                    return processCommentSortedResults(commentCountResult);
+                case "oldest":
+                    reviews = reviewRepository.findAllByOrderByCreatedAtAsc();
+                    break;
+                case "highest_rating":
+                    reviews = reviewRepository.findAllByOrderByRatingDesc();
+                    break;
+                case "lowest_rating":
+                    reviews = reviewRepository.findAllByOrderByRatingAsc();
+                    break;
+                case "newest":
+                default:
+                    reviews = reviewRepository.findAllByOrderByCreatedAtDesc();
+                    break;
+            }
+        }
+
+        // 각 리뷰의 댓글 수를 조회하여 DTO 생성
+        for (Review review : reviews) {
+            int commentCount = commentRepository.findByReviewReviewIdOrderByCreatedAtAsc(review.getReviewId()).size();
+            reviewDtos.add(new ReviewResponseDto(review, review.getMember().getNickname(), commentCount));
+        }
+
+        return reviewDtos;
+    }
+
+    // 댓글 수 기준 정렬 결과 처리
+    private List<ReviewResponseDto> processCommentSortedResults(List<Object[]> commentCountResult) {
+        List<ReviewResponseDto> reviewDtos = new ArrayList<>();
+
+        for (Object[] result : commentCountResult) {
+            Review review = (Review) result[0];
+            Long commentCount = (Long) result[1];
+
+            reviewDtos.add(new ReviewResponseDto(
+                    review,
+                    review.getMember().getNickname(),
+                    commentCount.intValue()
+            ));
+        }
+
+        return reviewDtos;
     }
 }


### PR DESCRIPTION

## 🔎 작업 내용

- 리뷰 목록을 다양한 조건으로 조회하는 기능 추가
    - 정렬 기준 조회(댓글 많은순, 최신순, 오래된순, 평점 높은순, 평점 낮은순)
    - 제목 검색, 여행지별, 회원별 리뷰 조회

  <br/>

<br/>

## ➕ 이슈 링크
- #38 

<br/>

<!-- closed #38  -->
