### PR TITLE
refact(#51) : 여행 일정 세부 일정 등록 방법 수정

### DIFF
--- a/backend/src/main/java/com/tripfriend/domain/trip/information/controller/TripInformationController.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/information/controller/TripInformationController.java
@@ -1,5 +1,6 @@
 package com.tripfriend.domain.trip.information.controller;
 
+import com.tripfriend.domain.trip.information.dto.TripInformationResDto;
 import com.tripfriend.domain.trip.information.dto.TripInformationUpdateReqDto;
 import com.tripfriend.domain.trip.information.entity.TripInformation;
 import com.tripfriend.domain.trip.information.service.TripInformationService;
@@ -19,15 +20,16 @@ public class TripInformationController {
 
     // 특정 여행 정보를 수정
     @PutMapping("/{tripInfoId}")
-    public RsData<TripInformation> updateTripInformation(
+    public RsData<TripInformationResDto> updateTripInformation(
             @PathVariable Long tripInfoId,
             @RequestBody @Valid TripInformationUpdateReqDto request) {
 
         TripInformation updatedTripInfo = tripInformationService.updateTripInformation(tripInfoId, request);
+        TripInformationResDto resDto = new TripInformationResDto(updatedTripInfo);// 반환 DTO
         return new RsData<>(
                 "200-1",
                 "여행 정보가 성공적으로 수정되었습니다.",
-                updatedTripInfo
+                resDto
         );
     }
 

--- a/backend/src/main/java/com/tripfriend/domain/trip/information/controller/TripInformationController.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/information/controller/TripInformationController.java
@@ -1,16 +1,34 @@
 package com.tripfriend.domain.trip.information.controller;
 
+import com.tripfriend.domain.trip.information.dto.TripInformationUpdateReqDto;
+import com.tripfriend.domain.trip.information.entity.TripInformation;
 import com.tripfriend.domain.trip.information.service.TripInformationService;
+import com.tripfriend.global.dto.RsData;
 import jakarta.persistence.Entity;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/trip/information")
 public class TripInformationController {
     private final TripInformationService tripInformationService;
+
+
+    // 특정 여행 정보를 수정
+    @PutMapping("/{tripInfoId}")
+    public RsData<TripInformation> updateTripInformation(
+            @PathVariable Long tripInfoId,
+            @RequestBody @Valid TripInformationUpdateReqDto request) {
+
+        TripInformation updatedTripInfo = tripInformationService.updateTripInformation(tripInfoId, request);
+        return new RsData<>(
+                "200-1",
+                "여행 정보가 성공적으로 수정되었습니다.",
+                updatedTripInfo
+        );
+    }
 
 }

--- a/backend/src/main/java/com/tripfriend/domain/trip/information/dto/TripInformationUpdateReqDto.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/information/dto/TripInformationUpdateReqDto.java
@@ -1,0 +1,29 @@
+package com.tripfriend.domain.trip.information.dto;
+
+import com.tripfriend.domain.trip.information.entity.Transportation;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TripInformationUpdateReqDto {
+    @NotNull
+    private Long placeId; // 장소 ID
+
+    @NotNull
+    private LocalDateTime visitTime;
+
+    @NotNull
+    private Integer duration;
+
+    private Transportation transportation;
+    private int cost;
+    private String notes;
+}

--- a/backend/src/main/java/com/tripfriend/domain/trip/information/dto/TripInformationUpdateReqDto.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/information/dto/TripInformationUpdateReqDto.java
@@ -14,16 +14,21 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TripInformationUpdateReqDto {
+
     @NotNull
+    private Long tripInformationId; // 여행 정보 ID
+
     private Long placeId; // 장소 ID
 
-    @NotNull
     private LocalDateTime visitTime;
 
-    @NotNull
     private Integer duration;
 
     private Transportation transportation;
+
     private int cost;
+
     private String notes;
+
+    private Boolean isVisited;
 }

--- a/backend/src/main/java/com/tripfriend/domain/trip/information/entity/TripInformation.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/information/entity/TripInformation.java
@@ -7,7 +7,9 @@ import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -30,10 +32,10 @@ public class TripInformation {
     @JoinColumn(name = "place_id", nullable = false)
     private Place place; // 여행지Id - FK
 
-    @Column(name = "visit_time",nullable = false)
+    @Column(name = "visit_time", nullable = false)
     private LocalDateTime visitTime; // 방문시간
 
-    @Column(name = "duration",nullable = false)
+    @Column(name = "duration", nullable = false)
     private Integer duration; // 방문기간(날짜 단위)
 
     @Column(name = "transportation", nullable = false)
@@ -42,7 +44,7 @@ public class TripInformation {
     @Column(name = "cost")
     private int cost; // 여행 경비
 
-    @Column(name = "notes",columnDefinition = "TEXT")
+    @Column(name = "notes", columnDefinition = "TEXT")
     private String notes; // 메모
 
     @Column(name = "priority")
@@ -52,11 +54,22 @@ public class TripInformation {
     @ColumnDefault("false")
     private boolean isVisited; // 방문여부
 
-    public void setTripSchedule(TripSchedule tripSchedule){
+    public void setTripSchedule(TripSchedule tripSchedule) {
         this.tripSchedule = tripSchedule;
     }
 
     public void setPlace(Place place) {
+        this.place = place;
+    }
+
+
+    // 여행 정보 수정 메서드
+    public void update(LocalDateTime visitTime, Integer duration, Transportation transportation, int cost, String notes, Place place) {
+        this.visitTime = visitTime;
+        this.duration = duration;
+        this.transportation = transportation;
+        this.cost = cost;
+        this.notes = notes;
         this.place = place;
     }
 }

--- a/backend/src/main/java/com/tripfriend/domain/trip/information/entity/TripInformation.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/information/entity/TripInformation.java
@@ -1,6 +1,7 @@
 package com.tripfriend.domain.trip.information.entity;
 
 import com.tripfriend.domain.place.place.entity.Place;
+import com.tripfriend.domain.trip.information.dto.TripInformationUpdateReqDto;
 import com.tripfriend.domain.trip.schedule.entity.TripSchedule;
 import jakarta.persistence.*;
 import lombok.*;
@@ -64,12 +65,12 @@ public class TripInformation {
 
 
     // 여행 정보 수정 메서드
-    public void update(LocalDateTime visitTime, Integer duration, Transportation transportation, int cost, String notes, Place place) {
-        this.visitTime = visitTime;
-        this.duration = duration;
-        this.transportation = transportation;
-        this.cost = cost;
-        this.notes = notes;
-        this.place = place;
+    public void updateTripInformation(TripInformationUpdateReqDto updateDto){
+        this.visitTime = updateDto.getVisitTime();
+        this.duration = updateDto.getDuration();
+        this.transportation = updateDto.getTransportation();
+        this.cost = updateDto.getCost();
+        this.notes = updateDto.getNotes();
+        this.isVisited = updateDto.getIsVisited();
     }
 }

--- a/backend/src/main/java/com/tripfriend/domain/trip/information/service/TripInformationService.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/information/service/TripInformationService.java
@@ -5,7 +5,6 @@ import com.tripfriend.domain.place.place.repository.PlaceRepository;
 import com.tripfriend.domain.trip.information.dto.TripInformationReqDto;
 import com.tripfriend.domain.trip.information.entity.TripInformation;
 import com.tripfriend.domain.trip.information.repository.TripInformationRepository;
-import com.tripfriend.domain.trip.schedule.dto.TripScheduleReqDto;
 import com.tripfriend.domain.trip.schedule.entity.TripSchedule;
 import com.tripfriend.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +21,7 @@ public class TripInformationService {
     private final TripInformationRepository tripInformationRepository;
     private final PlaceRepository placeRepository;
 
+    // 여행 정보 등록
     @Transactional
     public void addTripInformations(TripSchedule schedule, List<TripInformationReqDto> tripInfoReqs) {
 

--- a/backend/src/main/java/com/tripfriend/domain/trip/information/service/TripInformationService.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/information/service/TripInformationService.java
@@ -77,19 +77,8 @@ public class TripInformationService {
         TripInformation tripInformation = tripInformationRepository.findById(tripInfoId)
                 .orElseThrow(() -> new ServiceException("404-2", "해당 여행 정보가 존재하지 않습니다."));
 
-        // 요청된 장소가 존재하는지 확인
-        Place place = placeRepository.findById(req.getPlaceId())
-                .orElseThrow(() -> new ServiceException("404-3", "해당 장소가 존재하지 않습니다."));
-
-        // 여행 정보 업데이트
-        tripInformation.update(
-                req.getVisitTime(),
-                req.getDuration(),
-                req.getTransportation(),
-                req.getCost(),
-                req.getNotes(),
-                place
-        );
+        // 여행 정보 업데이트, DTO로 전달
+        tripInformation.updateTripInformation(req);
 
         return tripInformation;
     }

--- a/backend/src/main/java/com/tripfriend/domain/trip/information/service/TripInformationService.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/information/service/TripInformationService.java
@@ -1,13 +1,65 @@
 package com.tripfriend.domain.trip.information.service;
 
+import com.tripfriend.domain.place.place.entity.Place;
+import com.tripfriend.domain.place.place.repository.PlaceRepository;
+import com.tripfriend.domain.trip.information.dto.TripInformationReqDto;
+import com.tripfriend.domain.trip.information.entity.TripInformation;
 import com.tripfriend.domain.trip.information.repository.TripInformationRepository;
+import com.tripfriend.domain.trip.schedule.dto.TripScheduleReqDto;
+import com.tripfriend.domain.trip.schedule.entity.TripSchedule;
+import com.tripfriend.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class TripInformationService {
+
     private final TripInformationRepository tripInformationRepository;
+    private final PlaceRepository placeRepository;
 
+    @Transactional
+    public void addTripInformations(TripSchedule schedule, List<TripInformationReqDto> tripInfoReqs) {
 
+        // 요청된 여행지 정보가 없을 경우 처리 x
+        if (tripInfoReqs == null || tripInfoReqs.isEmpty()) {
+            return;
+        }
+
+        // TripInformation 리스트 생성 및 매핑
+        List<TripInformation> tripInformations = tripInfoReqs.stream()
+                .map(infoReq -> {
+                    if (infoReq.getPlaceId() == null) {
+                        throw new ServiceException("400-2", "장소 ID가 누락되었습니다.");
+                    }
+
+                    // 장소 검증
+                    Place place = placeRepository.findById(infoReq.getPlaceId()).orElseThrow(
+                            () -> new ServiceException("404-2", "해당 장소가 존재하지 않습니다.")
+                    );
+
+                    // 객체 생성 및 저장
+                    return TripInformation.builder()
+                            .tripSchedule(schedule)
+                            .place(place)
+                            .visitTime(infoReq.getVisitTime())
+                            .duration(infoReq.getDuration())
+                            .transportation(infoReq.getTransportation())
+                            .cost(infoReq.getCost())
+                            .notes(infoReq.getNotes())
+                            .priority(infoReq.getPriority())
+                            .isVisited(infoReq.isVisited())
+                            .build();
+                }).collect(Collectors.toList());
+
+        // 생성된 TripInformation 목록 저장
+        tripInformationRepository.saveAll(tripInformations);
+
+        // 여행 일정에 TripInformation 추가
+        schedule.addTripInformations(tripInformations);
+    }
 }

--- a/backend/src/main/java/com/tripfriend/domain/trip/information/service/TripInformationService.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/information/service/TripInformationService.java
@@ -3,6 +3,7 @@ package com.tripfriend.domain.trip.information.service;
 import com.tripfriend.domain.place.place.entity.Place;
 import com.tripfriend.domain.place.place.repository.PlaceRepository;
 import com.tripfriend.domain.trip.information.dto.TripInformationReqDto;
+import com.tripfriend.domain.trip.information.dto.TripInformationUpdateReqDto;
 import com.tripfriend.domain.trip.information.entity.TripInformation;
 import com.tripfriend.domain.trip.information.repository.TripInformationRepository;
 import com.tripfriend.domain.trip.schedule.entity.TripSchedule;
@@ -61,5 +62,35 @@ public class TripInformationService {
 
         // 여행 일정에 TripInformation 추가
         schedule.addTripInformations(tripInformations);
+    }
+
+    /**
+     * 특정 여행 정보를 수정하는 메서드
+     *
+     * @param tripInfoId 수정할 여행 정보 ID
+     * @param req        여행 정보 수정 요청 DTO
+     * @return 수정된 TripInformation 객체
+     */
+    @Transactional
+    public TripInformation updateTripInformation(Long tripInfoId, TripInformationUpdateReqDto req) {
+        // 여행 정보가 존재하는지 확인
+        TripInformation tripInformation = tripInformationRepository.findById(tripInfoId)
+                .orElseThrow(() -> new ServiceException("404-2", "해당 여행 정보가 존재하지 않습니다."));
+
+        // 요청된 장소가 존재하는지 확인
+        Place place = placeRepository.findById(req.getPlaceId())
+                .orElseThrow(() -> new ServiceException("404-3", "해당 장소가 존재하지 않습니다."));
+
+        // 여행 정보 업데이트
+        tripInformation.update(
+                req.getVisitTime(),
+                req.getDuration(),
+                req.getTransportation(),
+                req.getCost(),
+                req.getNotes(),
+                place
+        );
+
+        return tripInformation;
     }
 }

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
@@ -40,4 +40,16 @@ public class TripScheduleController {
         );
 
     }
+
+    // 특정 회원의 여행 일정 조회
+    @GetMapping("/member/{memberId}")
+    public RsData<List<TripScheduleResDto>> getSchedulesByMember(@PathVariable Long memberId) {
+        List<TripScheduleResDto> schedules = scheduleService.getSchedulesByMemberId(memberId);
+        return new RsData<>(
+                "200-3",
+                "특정 회원의 일정을 성공적으로 조회했습니다.",
+                schedules
+        );
+    }
+
 }

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
@@ -1,5 +1,7 @@
 package com.tripfriend.domain.trip.schedule.controller;
 
+import com.tripfriend.domain.member.member.entity.Member;
+import com.tripfriend.domain.member.member.repository.MemberRepository;
 import com.tripfriend.domain.trip.schedule.dto.TripScheduleReqDto;
 import com.tripfriend.domain.trip.schedule.dto.TripScheduleResDto;
 import com.tripfriend.domain.trip.schedule.dto.TripScheduleUpdateReqDto;
@@ -19,6 +21,7 @@ import java.util.List;
 public class TripScheduleController {
 
     private final TripScheduleService scheduleService;
+    private final MemberRepository memberRepository;
 
     // 일정 생성
     @PostMapping
@@ -47,10 +50,14 @@ public class TripScheduleController {
     // 특정 회원의 여행 일정 조회
     @GetMapping("/member/{memberId}")
     public RsData<List<TripScheduleResDto>> getSchedulesByMember(@PathVariable Long memberId) {
+
+        // 회원 이름 찾기
+        String memberName = scheduleService.getMemberName(memberId);
+
         List<TripScheduleResDto> schedules = scheduleService.getSchedulesByMemberId(memberId);
         return new RsData<>(
                 "200-3",
-                "특정 회원의 일정을 성공적으로 조회했습니다.",
+                "'%s'님의 일정을 성공적으로 조회했습니다.".formatted(memberName),
                 schedules
         );
     }
@@ -68,15 +75,16 @@ public class TripScheduleController {
 
     // 특정 여행 일정을 수정
     @PutMapping("/{scheduleId}")
-    public RsData<TripSchedule> updateSchedule(
+    public RsData<TripScheduleResDto> updateSchedule(
             @PathVariable Long scheduleId,
             @RequestBody @Valid TripScheduleUpdateReqDto req) {
 
         TripSchedule updatedSchedule = scheduleService.updateSchedule(scheduleId, req);
+        TripScheduleResDto resDto = new TripScheduleResDto(updatedSchedule); // 반환 DTO
         return new RsData<>(
                 "200-5",
                 "일정이 성공적으로 수정되었습니다.",
-                updatedSchedule
+                resDto
         );
     }
 

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
@@ -52,4 +52,14 @@ public class TripScheduleController {
         );
     }
 
+    // 일정 삭제
+    @DeleteMapping("/{scheduleId}")
+    public RsData<Void> deleteSchedule(@PathVariable Long scheduleId) {
+        scheduleService.deleteSchedule(scheduleId);
+        return new RsData<>(
+                "200-4",
+                "일정이 성공적으로 삭제되었습니다."
+        );
+    }
+
 }

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
@@ -2,9 +2,7 @@ package com.tripfriend.domain.trip.schedule.controller;
 
 import com.tripfriend.domain.member.member.entity.Member;
 import com.tripfriend.domain.member.member.repository.MemberRepository;
-import com.tripfriend.domain.trip.schedule.dto.TripScheduleReqDto;
-import com.tripfriend.domain.trip.schedule.dto.TripScheduleResDto;
-import com.tripfriend.domain.trip.schedule.dto.TripScheduleUpdateReqDto;
+import com.tripfriend.domain.trip.schedule.dto.*;
 import com.tripfriend.domain.trip.schedule.entity.TripSchedule;
 import com.tripfriend.domain.trip.schedule.service.TripScheduleService;
 import com.tripfriend.global.dto.RsData;
@@ -85,6 +83,16 @@ public class TripScheduleController {
                 "200-5",
                 "일정이 성공적으로 수정되었습니다.",
                 resDto
+        );
+    }
+
+    @PutMapping("/update")
+    public RsData<TripUpdateResDto> updateTrip(@RequestBody @Valid TripUpdateReqDto reqDto) {
+        TripUpdateResDto resTrip = scheduleService.updateTrip(reqDto);
+        return new RsData<>(
+                "200-1",
+                "여행 일정 및 여행 정보가 성공적으로 수정되었습니다.",
+                resTrip
         );
     }
 

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
@@ -2,10 +2,13 @@ package com.tripfriend.domain.trip.schedule.controller;
 
 import com.tripfriend.domain.trip.schedule.dto.TripScheduleReqDto;
 import com.tripfriend.domain.trip.schedule.dto.TripScheduleResDto;
+import com.tripfriend.domain.trip.schedule.dto.TripScheduleUpdateReqDto;
 import com.tripfriend.domain.trip.schedule.entity.TripSchedule;
 import com.tripfriend.domain.trip.schedule.service.TripScheduleService;
 import com.tripfriend.global.dto.RsData;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -52,13 +55,28 @@ public class TripScheduleController {
         );
     }
 
-    // 일정 삭제
+    // 여행 일정 삭제
     @DeleteMapping("/{scheduleId}")
     public RsData<Void> deleteSchedule(@PathVariable Long scheduleId) {
         scheduleService.deleteSchedule(scheduleId);
         return new RsData<>(
                 "200-4",
                 "일정이 성공적으로 삭제되었습니다."
+        );
+    }
+
+
+    // 특정 여행 일정을 수정
+    @PutMapping("/{scheduleId}")
+    public RsData<TripSchedule> updateSchedule(
+            @PathVariable Long scheduleId,
+            @RequestBody @Valid TripScheduleUpdateReqDto req) {
+
+        TripSchedule updatedSchedule = scheduleService.updateSchedule(scheduleId, req);
+        return new RsData<>(
+                "200-5",
+                "일정이 성공적으로 수정되었습니다.",
+                updatedSchedule
         );
     }
 

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/dto/TripScheduleResDto.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/dto/TripScheduleResDto.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 @Getter
 public class TripScheduleResDto {
     private Long id;
-    private Long memberId;
+    private String memberName;
     private String title;
     private String description;
     private LocalDate startDate;
@@ -24,7 +24,7 @@ public class TripScheduleResDto {
     // TripSchedule 엔티티를 DTO로 변환하는 생성자
     public TripScheduleResDto(TripSchedule tripSchedule) {
         this.id = tripSchedule.getId();
-        this.memberId = tripSchedule.getMember().getId();
+        this.memberName = tripSchedule.getMember().getUsername();
         this.title = tripSchedule.getTitle();
         this.description = tripSchedule.getDescription();
         this.startDate = tripSchedule.getStartDate();

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/dto/TripScheduleUpdateReqDto.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/dto/TripScheduleUpdateReqDto.java
@@ -1,0 +1,28 @@
+package com.tripfriend.domain.trip.schedule.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TripScheduleUpdateReqDto {
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String description;
+
+    @NotNull
+    private LocalDate startDate;
+
+    @NotNull
+    private LocalDate endDate;
+}

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/dto/TripUpdateReqDto.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/dto/TripUpdateReqDto.java
@@ -1,0 +1,25 @@
+package com.tripfriend.domain.trip.schedule.dto;
+
+
+import com.tripfriend.domain.trip.information.dto.TripInformationUpdateReqDto;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TripUpdateReqDto {
+
+    @NotNull
+    private Long tripScheduleId;  // 여행 일정 ID
+
+    @Valid
+    private TripScheduleUpdateReqDto scheduleUpdate; // 여행 일정 수정 정보
+
+    @Valid
+    private List<TripInformationUpdateReqDto> tripInformationUpdates; // 여행 정보 수정 리스트
+}

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/dto/TripUpdateResDto.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/dto/TripUpdateResDto.java
@@ -1,0 +1,31 @@
+package com.tripfriend.domain.trip.schedule.dto;
+
+import com.tripfriend.domain.trip.information.dto.TripInformationResDto;
+import com.tripfriend.domain.trip.information.entity.TripInformation;
+import com.tripfriend.domain.trip.schedule.entity.TripSchedule;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class TripUpdateResDto {
+
+    // 수정된 여행 일정 정보를 담는 DTO
+    private final TripScheduleResDto updatedSchedule;
+
+    // 수정된 여행 정보 리스트를 담는 DTO
+    private final List<TripInformationResDto> updatedTripInformations;
+
+    /**
+     * TripUpdateResDto 생성자
+     *
+     * @param tripSchedule       수정된 여행 일정 엔티티
+     * @param tripInformations   수정된 여행 정보 리스트 엔티티
+     */
+    public TripUpdateResDto(TripSchedule tripSchedule, List<TripInformation> tripInformations) {
+        this.updatedSchedule = new TripScheduleResDto(tripSchedule); // 일정 정보를 DTO로 변환
+        this.updatedTripInformations = tripInformations.stream()
+                .map(TripInformationResDto::new) // 여행 정보 리스트를 DTO로 변환
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/entity/TripSchedule.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/entity/TripSchedule.java
@@ -60,10 +60,19 @@ public class TripSchedule {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt; // 수정일
 
+    // 단일 TripInformation을 여행 일정에 추가
     public void addTripInfromation(TripInformation tripInformation){
         this.tripInformations.add(tripInformation);
         tripInformation.setTripSchedule(this); // 연관 관계 설정
     }
 
+    // 여행 일정에 여러 개의 TripInformation을 추가
+    public void addTripInformations(List<TripInformation> tripInformations) {
+        if(tripInformations != null){
+            for(TripInformation tripInformation : tripInformations){
+                addTripInfromation(tripInformation);
+            }
+        }
+    }
 }
 

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/entity/TripSchedule.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/entity/TripSchedule.java
@@ -74,5 +74,14 @@ public class TripSchedule {
             }
         }
     }
+
+    // 여행 일정 정보 수정 메서드
+    public void update(String title, String description, LocalDate startDate, LocalDate endDate) {
+        this.title = title;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.updatedAt = LocalDateTime.now(); // 수정 시간 업데이트
+    }
 }
 

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/entity/TripSchedule.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/entity/TripSchedule.java
@@ -3,6 +3,7 @@ package com.tripfriend.domain.trip.schedule.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.tripfriend.domain.member.member.entity.Member;
 import com.tripfriend.domain.trip.information.entity.TripInformation;
+import com.tripfriend.domain.trip.schedule.dto.TripScheduleUpdateReqDto;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -76,11 +77,11 @@ public class TripSchedule {
     }
 
     // 여행 일정 정보 수정 메서드
-    public void update(String title, String description, LocalDate startDate, LocalDate endDate) {
-        this.title = title;
-        this.description = description;
-        this.startDate = startDate;
-        this.endDate = endDate;
+    public void updateSchedule(TripScheduleUpdateReqDto scheduleUpdate) {
+        this.title = scheduleUpdate.getTitle();
+        this.description = scheduleUpdate.getDescription();
+        this.startDate = scheduleUpdate.getStartDate();
+        this.endDate = scheduleUpdate.getEndDate();
         this.updatedAt = LocalDateTime.now(); // 수정 시간 업데이트
     }
 }

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
@@ -9,6 +9,7 @@ import com.tripfriend.domain.trip.information.repository.TripInformationReposito
 import com.tripfriend.domain.trip.information.service.TripInformationService;
 import com.tripfriend.domain.trip.schedule.dto.TripScheduleReqDto;
 import com.tripfriend.domain.trip.schedule.dto.TripScheduleResDto;
+import com.tripfriend.domain.trip.schedule.dto.TripScheduleUpdateReqDto;
 import com.tripfriend.domain.trip.schedule.entity.TripSchedule;
 import com.tripfriend.domain.trip.schedule.repository.TripScheduleRepository;
 import com.tripfriend.global.exception.ServiceException;
@@ -89,10 +90,30 @@ public class TripScheduleService {
                 .collect(Collectors.toList());
     }
 
+    // 여행 일정 삭제
     @Transactional
     public void deleteSchedule(Long scheduleId) {
         TripSchedule schedule = tripScheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new ServiceException("404-1", "해당 일정이 존재하지 않습니다."));
         tripScheduleRepository.delete(schedule);
+    }
+
+    /**
+     * 특정 여행 일정을 수정하는 메서드
+     *
+     * @param scheduleId 수정할 여행 일정의 ID
+     * @param req        일정 수정 요청 DTO
+     * @return 수정된 TripSchedule 객체
+     */
+    @Transactional
+    public TripSchedule updateSchedule(Long scheduleId, TripScheduleUpdateReqDto req) {
+        // 여행 일정이 존재하는지 확인
+        TripSchedule schedule = tripScheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new ServiceException("404-1", "해당 일정이 존재하지 않습니다."));
+
+        // 일정 정보 업데이트
+        schedule.update(req.getTitle(), req.getDescription(), req.getStartDate(), req.getEndDate());
+
+        return schedule;
     }
 }

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
@@ -59,7 +59,7 @@ public class TripScheduleService {
     public List<TripScheduleResDto> getAllSchedules() {
         List<TripSchedule> schedules = tripScheduleRepository.findAll();
 
-        if (schedules.isEmpty()){
+        if (schedules.isEmpty()) {
             throw new ServiceException("404-3", "여행 일정이 존재하지 않습니다.");
         }
 
@@ -80,12 +80,19 @@ public class TripScheduleService {
         List<TripSchedule> schedules = tripScheduleRepository.findByMemberId(memberId);
 
         // 여행 일정 존재 여부 검증
-        if(schedules.isEmpty()){
+        if (schedules.isEmpty()) {
             throw new ServiceException("404-3", "해당 회원의 여행 일정이 존재하지 않습니다.");
         }
 
         return schedules.stream()
                 .map(TripScheduleResDto::new)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteSchedule(Long scheduleId) {
+        TripSchedule schedule = tripScheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new ServiceException("404-1", "해당 일정이 존재하지 않습니다."));
+        tripScheduleRepository.delete(schedule);
     }
 }

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
@@ -6,6 +6,7 @@ import com.tripfriend.domain.place.place.entity.Place;
 import com.tripfriend.domain.place.place.repository.PlaceRepository;
 import com.tripfriend.domain.trip.information.entity.TripInformation;
 import com.tripfriend.domain.trip.information.repository.TripInformationRepository;
+import com.tripfriend.domain.trip.information.service.TripInformationService;
 import com.tripfriend.domain.trip.schedule.dto.TripScheduleReqDto;
 import com.tripfriend.domain.trip.schedule.dto.TripScheduleResDto;
 import com.tripfriend.domain.trip.schedule.entity.TripSchedule;
@@ -24,8 +25,7 @@ public class TripScheduleService {
 
     private final TripScheduleRepository tripScheduleRepository;
     private final MemberRepository memberRepository;
-    private final PlaceRepository placeRepository;
-    private final TripInformationRepository tripInformationRepository;
+    private final TripInformationService tripInformationService;
 
     // 여행 일정 생성
     @Transactional
@@ -46,33 +46,9 @@ public class TripScheduleService {
                 .build();
         tripScheduleRepository.save(newSchedule);
 
-        // TripInformation 테이블에 여행지 정보 저장(N:M 관계)
-        List<TripInformation> tripInformations = req.getTripInformations()
-                .stream()
-                .map(infoReq -> {
-                    if (infoReq.getPlaceId() == null) {
-                        throw new ServiceException("400-2", "장소 ID가 누락 되었습니다.");
-                    }
-                    Place place = placeRepository.findById(infoReq.getPlaceId()).orElseThrow(
-                            () -> new ServiceException("404-1", "해당 장소가 존재하지 않습니다.")
-                    ); // 여행 장소 확인
-                    return TripInformation.builder()
-                            .tripSchedule(newSchedule)
-                            .place(place)
-                            .visitTime(infoReq.getVisitTime())
-                            .duration(infoReq.getDuration())
-                            .transportation(infoReq.getTransportation())
-                            .cost(infoReq.getCost())
-                            .notes(infoReq.getNotes())
-                            .priority(infoReq.getPriority())
-                            .isVisited(infoReq.isVisited())
-                            .build();
-                }).collect(Collectors.toList());
-
-        tripInformationRepository.saveAll(tripInformations);
-
-        for (TripInformation tripInformation : tripInformations) {
-            newSchedule.addTripInfromation(tripInformation);
+        // TripInformation 추가 (여행지 정보)
+        if (req.getTripInformations() != null && !req.getTripInformations().isEmpty()) {
+            tripInformationService.addTripInformations(newSchedule, req.getTripInformations());
         }
 
         return new TripScheduleResDto(newSchedule);

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
@@ -69,6 +69,14 @@ public class TripScheduleService {
                 .collect(Collectors.toList());
     }
 
+    // 회원 이름 조회
+    @Transactional(readOnly = true)
+    public String getMemberName(Long memberId) {
+        return memberRepository.findById(memberId)
+                .map(Member::getUsername)
+                .orElseThrow(() -> new ServiceException("404-1", "해당 회원이 존재하지 않습니다."));
+    }
+
     // 특정 회원의 여행 일정 조회
     @Transactional(readOnly = true)
     public List<TripScheduleResDto> getSchedulesByMemberId(Long memberId) {

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
@@ -55,9 +55,35 @@ public class TripScheduleService {
     }
 
     // 전체 일정 조회
-    @Transactional
+    @Transactional(readOnly = true)
     public List<TripScheduleResDto> getAllSchedules() {
         List<TripSchedule> schedules = tripScheduleRepository.findAll();
+
+        if (schedules.isEmpty()){
+            throw new ServiceException("404-3", "여행 일정이 존재하지 않습니다.");
+        }
+
+        return schedules.stream()
+                .map(TripScheduleResDto::new)
+                .collect(Collectors.toList());
+    }
+
+    // 특정 회원의 여행 일정 조회
+    @Transactional(readOnly = true)
+    public List<TripScheduleResDto> getSchedulesByMemberId(Long memberId) {
+        // 회원 존재 여부 검증
+        if (!memberRepository.existsById(memberId)) {
+            throw new ServiceException("404-1", "해당 회원이 존재하지 않습니다.");
+        }
+
+        // 회원 ID로 여행 일정 조회
+        List<TripSchedule> schedules = tripScheduleRepository.findByMemberId(memberId);
+
+        // 여행 일정 존재 여부 검증
+        if(schedules.isEmpty()){
+            throw new ServiceException("404-3", "해당 회원의 여행 일정이 존재하지 않습니다.");
+        }
+
         return schedules.stream()
                 .map(TripScheduleResDto::new)
                 .collect(Collectors.toList());


### PR DESCRIPTION
## 🔎 작업 내용

- 여행 일정, 여행정보(세부)일정에 대한 로직을 분리함

- 특정 회원이 자신에 일정에 대해 조회 가능

- 여행 일정 삭제 기능을 구현함

- 여행 일정 수정 기능 구현

- 여행 정보 수정 기능 구현

- 여행 정보, 여행 일정 통합 수정 기능 구현

  <br/>

## ➕ 이슈 링크
- [GODAOS/re-51 #51 ](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team10/issues/51)

<br/>

<!-- closed #51  -->
