### PR TITLE
refact(#66) : 여행지, 여행 일정 리팩토링

### DIFF
--- a/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
@@ -5,10 +5,10 @@ import com.tripfriend.domain.place.place.dto.PlaceResDto;
 import com.tripfriend.domain.place.place.dto.PlaceUpdateReqDto;
 import com.tripfriend.domain.place.place.entity.Place;
 import com.tripfriend.domain.place.place.service.PlaceService;
+import com.tripfriend.global.dto.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,53 +24,65 @@ public class PlaceController {
     // 여행지 등록
     @PostMapping
     @Operation(summary = "여행지 등록")
-    public ResponseEntity<Place> createPlace(@RequestBody PlaceCreateReqDto placeCreateRequestDto) {
-        Place savePlace = placeService.createPlace(placeCreateRequestDto);
-        return ResponseEntity.ok(savePlace);
+    public RsData<PlaceResDto> createPlace(@RequestBody PlaceCreateReqDto req) {
+        Place savePlace = placeService.createPlace(req);
+        PlaceResDto placeResDto = new PlaceResDto(savePlace);
+        return new RsData<>(
+                "200-1",
+                "여행지가 성공적으로 등록되었습니다.",
+                placeResDto
+        );
     }
 
     // 전체 여행지 조회
     @GetMapping
     @Operation(summary = "전체 여행지 조회")
-    public ResponseEntity<List<Place>> getAllPlaces() {
-        return ResponseEntity.ok(placeService.getAllPlaces());
+    public RsData<List<PlaceResDto>> getAllPlaces() {
+        List<Place> places = placeService.getAllPlaces();
+        List<PlaceResDto> placeResDtos = places.stream().map(PlaceResDto::new).toList();
+        return new RsData<>(
+                "200-2",
+                "전체 여행지가 성공적으로 조회되었습니다.",
+                placeResDtos
+        );
     }
 
-    // 여행지 조회 - 단건 조회
+    // 특정 여행지 조회 - 단건 조회
     @GetMapping("/{id}")
     @Operation(summary = "여행지 조회")
-    public ResponseEntity<Place> getPlace(@PathVariable Long id) {
-        Place place = placeService.getPlace(id).orElseThrow(
-                () -> new RuntimeException("존재하지 않는 장소입니다.")
+    public RsData<PlaceResDto> getPlace(@PathVariable Long id) {
+        Place place = placeService.getPlace(id);
+        PlaceResDto placeResDto = new PlaceResDto(place);
+        return new RsData<>(
+                "200-3",
+                "여행지가 성공적으로 조회되었습니다.",
+                placeResDto
         );
-
-        return ResponseEntity.ok(place);
     }
 
-    // 여행지 삭제
+    // 특정 여행지 삭제
     @DeleteMapping("/{id}")
     @Operation(summary = "여행지 삭제")
-    public ResponseEntity<Void> deletePlace(@PathVariable Long id) {
-
-        Place place = placeService.getPlace(id).orElseThrow(
-                () -> new RuntimeException("존재하지 않는 장소입니다.")
-        );
-
+    public RsData<Void> deletePlace(@PathVariable Long id) {
+        Place place = placeService.getPlace(id);
         placeService.deletePlace(place);
-        return ResponseEntity.noContent().build();
+        return new RsData<>(
+                "200-4",
+                "여행지가 성공적으로 삭제되었습니다."
+        );
     }
 
-    // 여행지 정보 수정
+    // 특정 여행지 정보 수정
     @PutMapping("/{id}")
     @Operation(summary = "여행지 정보 수정")
-    public ResponseEntity<PlaceResDto> updatePlace(@PathVariable Long id, @RequestBody PlaceUpdateReqDto placeUpdateReqDto) {
-        Place place = placeService.getPlace(id).orElseThrow(
-                () -> new RuntimeException("존재하지 않는 장소입니다.")
+    public RsData<PlaceResDto> updatePlace(@PathVariable Long id, @RequestBody PlaceUpdateReqDto placeUpdateReqDto) {
+        Place place = placeService.getPlace(id);
+        Place updatePlace = placeService.updatePlace(place, placeUpdateReqDto);
+        PlaceResDto placeResDto = new PlaceResDto(updatePlace);
+        return new RsData<>(
+                "200-5",
+                "여행지 정보가 성공적으로 수정되었습니다.",
+                placeResDto
         );
-
-        PlaceResDto updatePlace = placeService.updatePlace(place, placeUpdateReqDto);
-        return ResponseEntity.ok(updatePlace);
     }
-
-
 }

--- a/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
@@ -5,6 +5,8 @@ import com.tripfriend.domain.place.place.dto.PlaceResDto;
 import com.tripfriend.domain.place.place.dto.PlaceUpdateReqDto;
 import com.tripfriend.domain.place.place.entity.Place;
 import com.tripfriend.domain.place.place.service.PlaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,25 +16,29 @@ import java.util.List;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/place")
+@Tag(name = "Place API", description = "여행지 관련 기능을 제공합니다.")
 public class PlaceController {
 
     private final PlaceService placeService;
 
-    // 여행 장소 등록
+    // 여행지 등록
     @PostMapping
+    @Operation(summary = "여행지 등록")
     public ResponseEntity<Place> createPlace(@RequestBody PlaceCreateReqDto placeCreateRequestDto) {
         Place savePlace = placeService.createPlace(placeCreateRequestDto);
         return ResponseEntity.ok(savePlace);
     }
 
-    // 모든 여행 장소 조회
+    // 전체 여행지 조회
     @GetMapping
+    @Operation(summary = "전체 여행지 조회")
     public ResponseEntity<List<Place>> getAllPlaces() {
         return ResponseEntity.ok(placeService.getAllPlaces());
     }
 
-    // 여행 장소 - 단건 조회
+    // 여행지 조회 - 단건 조회
     @GetMapping("/{id}")
+    @Operation(summary = "여행지 조회")
     public ResponseEntity<Place> getPlace(@PathVariable Long id) {
         Place place = placeService.getPlace(id).orElseThrow(
                 () -> new RuntimeException("존재하지 않는 장소입니다.")
@@ -41,8 +47,9 @@ public class PlaceController {
         return ResponseEntity.ok(place);
     }
 
-    // 여행 장소 삭제
+    // 여행지 삭제
     @DeleteMapping("/{id}")
+    @Operation(summary = "여행지 삭제")
     public ResponseEntity<Void> deletePlace(@PathVariable Long id) {
 
         Place place = placeService.getPlace(id).orElseThrow(
@@ -53,8 +60,9 @@ public class PlaceController {
         return ResponseEntity.noContent().build();
     }
 
-    // 여행 장소 수정
+    // 여행지 정보 수정
     @PutMapping("/{id}")
+    @Operation(summary = "여행지 정보 수정")
     public ResponseEntity<PlaceResDto> updatePlace(@PathVariable Long id, @RequestBody PlaceUpdateReqDto placeUpdateReqDto) {
         Place place = placeService.getPlace(id).orElseThrow(
                 () -> new RuntimeException("존재하지 않는 장소입니다.")

--- a/backend/src/main/java/com/tripfriend/domain/place/place/dto/PlaceCreateReqDto.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/dto/PlaceCreateReqDto.java
@@ -24,6 +24,7 @@ public class PlaceCreateReqDto {
     @NotNull(message = "카테고리를 선택해주세요")
     private Category category;
 
+    // DTO -> Entity 변환
     public Place toEntity(){
         return Place.builder()
                 .cityName(cityName)

--- a/backend/src/main/java/com/tripfriend/domain/place/place/service/PlaceService.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/service/PlaceService.java
@@ -5,6 +5,7 @@ import com.tripfriend.domain.place.place.dto.PlaceResDto;
 import com.tripfriend.domain.place.place.dto.PlaceUpdateReqDto;
 import com.tripfriend.domain.place.place.entity.Place;
 import com.tripfriend.domain.place.place.repository.PlaceRepository;
+import com.tripfriend.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,19 +19,23 @@ public class PlaceService {
     private final PlaceRepository placeRepository;
 
     // 여행 장소 등록
-    public Place createPlace(PlaceCreateReqDto placeCreateRequestDto) {
-        Place place = placeCreateRequestDto.toEntity();
-        return placeRepository.save(place);
+    public Place createPlace(PlaceCreateReqDto req) {
+        Place place = req.toEntity();
+        placeRepository.save(place);
+
+        return place;
     }
 
     // 여행 장소 전체 리스트 조회
     public List<Place> getAllPlaces() {
-        return placeRepository.findAll();
+        List<Place> places = placeRepository.findAll();
+        return places;
     }
 
     // 여행 장소 단건 조회
-    public Optional<Place> getPlace(Long id) {
-        return placeRepository.findById(id);
+    public Place getPlace(Long id) {
+        return placeRepository.findById(id)
+                .orElseThrow(() -> new ServiceException("404-1", "해당 장소가 존재하지 않습니다."));
     }
 
     // 여행 장소 삭제
@@ -41,13 +46,12 @@ public class PlaceService {
 
     // 여행 장소 수정
     @Transactional
-    public PlaceResDto updatePlace(Place place, PlaceUpdateReqDto placeUpdateReqDto) {
-        place.setCityName(placeUpdateReqDto.getCityName());
-        place.setPlaceName(placeUpdateReqDto.getPlaceName());
-        place.setDescription(placeUpdateReqDto.getDescription());
-        place.setCategory(placeUpdateReqDto.getCategory());
+    public Place updatePlace(Place place, PlaceUpdateReqDto req) {
+        place.setCityName(req.getCityName());
+        place.setPlaceName(req.getPlaceName());
+        place.setDescription(req.getDescription());
+        place.setCategory(req.getCategory());
 
-        Place updatePlace = placeRepository.save(place);
-        return new PlaceResDto(updatePlace);
+        return placeRepository.save(place);
     }
 }

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
@@ -62,19 +62,10 @@ public class TripScheduleController {
     @Operation(summary = "나의 여행 일정 전체 조회")
     public RsData<List<TripScheduleResDto>> getMySchedules(@RequestHeader(value = "Authorization", required = false) String token) {
 
-        // 로그인 확인
-        Member loggedInMember = authService.getLoggedInMember(token);
-
-        // 회원 아이디 가져오기
-        Long memberId = loggedInMember.getId();
-        // 회원 이름 가져오기
-        String memberName = loggedInMember.getUsername();
-
-
-        List<TripScheduleResDto> schedules = scheduleService.getSchedulesByCreator(memberId);
+        List<TripScheduleResDto> schedules = scheduleService.getSchedulesByCreator(token);
         return new RsData<>(
                 "200-6",
-                "'%s'님이 생성한 일정 조회가 완료되었습니다.".formatted(memberName),
+                "'%s'님이 생성한 일정 조회가 완료되었습니다.".formatted(schedules.get(0).getMemberName()),
                 schedules
         );
     }

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
@@ -2,10 +2,13 @@ package com.tripfriend.domain.trip.schedule.controller;
 
 import com.tripfriend.domain.member.member.entity.Member;
 import com.tripfriend.domain.member.member.repository.MemberRepository;
+import com.tripfriend.domain.member.member.service.AuthService;
 import com.tripfriend.domain.trip.schedule.dto.*;
 import com.tripfriend.domain.trip.schedule.entity.TripSchedule;
 import com.tripfriend.domain.trip.schedule.service.TripScheduleService;
 import com.tripfriend.global.dto.RsData;
+import com.tripfriend.global.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +22,9 @@ import java.util.List;
 public class TripScheduleController {
 
     private final TripScheduleService scheduleService;
+    private final AuthService authService;
     private final MemberRepository memberRepository;
+
 
     // 일정 생성
     @PostMapping
@@ -43,6 +48,27 @@ public class TripScheduleController {
                 schedules
         );
 
+    }
+
+    // 로그인한 회원이 자신의 여행 일정을 조회
+    @GetMapping("/my-schedules")
+    public RsData<List<TripScheduleResDto>> getMySchedules(@RequestHeader(value = "Authorization", required = false) String token) {
+
+        // 로그인 확인
+        Member loggedInMember = authService.getLoggedInMember(token);
+
+        // 회원 아이디 가져오기
+        Long memberId = loggedInMember.getId();
+        // 회원 이름 가져오기
+        String memberName = loggedInMember.getUsername();
+
+
+        List<TripScheduleResDto> schedules = scheduleService.getSchedulesByCreator(memberId);
+        return new RsData<>(
+                "200-6",
+                "'%s'님이 생성한 일정 조회가 완료되었습니다.".formatted(memberName),
+                schedules
+        );
     }
 
     // 특정 회원의 여행 일정 조회

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
@@ -91,11 +91,12 @@ public class TripScheduleController {
 
     // 여행 일정 삭제
     @DeleteMapping("/my-schedules/{scheduleId}")
-    public RsData<Void> deleteSchedule(@PathVariable Long scheduleId) {
+    public RsData<Void> deleteSchedule(@PathVariable Long scheduleId,
+                                       @RequestHeader(value = "Authorization", required = false) String token) {
 
 
 
-        scheduleService.deleteSchedule(scheduleId);
+        scheduleService.deleteSchedule(scheduleId, token);
         return new RsData<>(
                 "200-4",
                 "일정이 성공적으로 삭제되었습니다."

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
@@ -89,12 +89,10 @@ public class TripScheduleController {
         );
     }
 
-    // 여행 일정 삭제
+    // 개인 여행 일정 삭제
     @DeleteMapping("/my-schedules/{scheduleId}")
     public RsData<Void> deleteSchedule(@PathVariable Long scheduleId,
                                        @RequestHeader(value = "Authorization", required = false) String token) {
-
-
 
         scheduleService.deleteSchedule(scheduleId, token);
         return new RsData<>(
@@ -120,8 +118,9 @@ public class TripScheduleController {
     }
 
     @PutMapping("/update")
-    public RsData<TripUpdateResDto> updateTrip(@RequestBody @Valid TripUpdateReqDto reqDto) {
-        TripUpdateResDto resTrip = scheduleService.updateTrip(reqDto);
+    public RsData<TripUpdateResDto> updateTrip(@RequestBody @Valid TripUpdateReqDto reqDto,
+                                               @RequestHeader(value = "Authorization", required = false) String token) {
+        TripUpdateResDto resTrip = scheduleService.updateTrip(reqDto, token);
         return new RsData<>(
                 "200-1",
                 "여행 일정 및 여행 정보가 성공적으로 수정되었습니다.",

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
@@ -7,6 +7,7 @@ import com.tripfriend.domain.trip.schedule.dto.*;
 import com.tripfriend.domain.trip.schedule.entity.TripSchedule;
 import com.tripfriend.domain.trip.schedule.service.TripScheduleService;
 import com.tripfriend.global.dto.RsData;
+import com.tripfriend.global.exception.ServiceException;
 import com.tripfriend.global.util.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -23,14 +24,16 @@ public class TripScheduleController {
 
     private final TripScheduleService scheduleService;
     private final AuthService authService;
-    private final MemberRepository memberRepository;
 
 
-    // 일정 생성
+    // 개인 일정 생성
     @PostMapping
-    public RsData<TripScheduleResDto> createSchedule(@RequestBody TripScheduleReqDto reqBody) {
-        System.out.println("확인" + reqBody);
-        TripScheduleResDto schedule = scheduleService.createSchedule(reqBody);
+    public RsData<TripScheduleResDto> createSchedule(@RequestBody TripScheduleReqDto reqBody,
+                                                     @RequestHeader(value = "Authorization", required = false) String token) {
+
+
+        // 일정 생성
+        TripScheduleResDto schedule = scheduleService.createSchedule(reqBody, token);
         return new RsData<>(
                 "200-1",
                 "일정이 성공적으로 생성되었습니다.",
@@ -38,7 +41,7 @@ public class TripScheduleController {
         );
     }
 
-    // 전체 일정 조회
+    // 전체 일정 조회(필요없을지도)
     @GetMapping
     public RsData<List<TripScheduleResDto>> getAllSchedules() {
         List<TripScheduleResDto> schedules = scheduleService.getAllSchedules();
@@ -71,7 +74,7 @@ public class TripScheduleController {
         );
     }
 
-    // 특정 회원의 여행 일정 조회
+    // 특정 회원의 여행 일정 조회(필요없음)
     @GetMapping("/member/{memberId}")
     public RsData<List<TripScheduleResDto>> getSchedulesByMember(@PathVariable Long memberId) {
 
@@ -87,8 +90,11 @@ public class TripScheduleController {
     }
 
     // 여행 일정 삭제
-    @DeleteMapping("/{scheduleId}")
+    @DeleteMapping("/my-schedules/{scheduleId}")
     public RsData<Void> deleteSchedule(@PathVariable Long scheduleId) {
+
+
+
         scheduleService.deleteSchedule(scheduleId);
         return new RsData<>(
                 "200-4",

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/controller/TripScheduleController.java
@@ -9,6 +9,8 @@ import com.tripfriend.domain.trip.schedule.service.TripScheduleService;
 import com.tripfriend.global.dto.RsData;
 import com.tripfriend.global.exception.ServiceException;
 import com.tripfriend.global.util.JwtUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/trip/schedule")
+@Tag(name = "TripSchedule API", description = "여행일정 관련 기능을 제공합니다.")
 public class TripScheduleController {
 
     private final TripScheduleService scheduleService;
@@ -28,6 +31,7 @@ public class TripScheduleController {
 
     // 개인 일정 생성
     @PostMapping
+    @Operation(summary = "나의 여행 일정 등록")
     public RsData<TripScheduleResDto> createSchedule(@RequestBody TripScheduleReqDto reqBody,
                                                      @RequestHeader(value = "Authorization", required = false) String token) {
 
@@ -55,6 +59,7 @@ public class TripScheduleController {
 
     // 로그인한 회원이 자신의 여행 일정을 조회
     @GetMapping("/my-schedules")
+    @Operation(summary = "나의 여행 일정 전체 조회")
     public RsData<List<TripScheduleResDto>> getMySchedules(@RequestHeader(value = "Authorization", required = false) String token) {
 
         // 로그인 확인
@@ -90,6 +95,7 @@ public class TripScheduleController {
     }
 
     // 개인 여행 일정 삭제
+    @Operation(summary = "나의 여행 일정 삭제")
     @DeleteMapping("/my-schedules/{scheduleId}")
     public RsData<Void> deleteSchedule(@PathVariable Long scheduleId,
                                        @RequestHeader(value = "Authorization", required = false) String token) {
@@ -118,6 +124,7 @@ public class TripScheduleController {
     }
 
     @PutMapping("/update")
+    @Operation(summary = "나의 여행 일정 및 여행 정보 통합 수정")
     public RsData<TripUpdateResDto> updateTrip(@RequestBody @Valid TripUpdateReqDto reqDto,
                                                @RequestHeader(value = "Authorization", required = false) String token) {
         TripUpdateResDto resTrip = scheduleService.updateTrip(reqDto, token);

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/dto/TripScheduleReqDto.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/dto/TripScheduleReqDto.java
@@ -4,12 +4,14 @@ import com.tripfriend.domain.trip.information.dto.TripInformationReqDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class TripScheduleReqDto {
     private Long memberId;

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
@@ -118,11 +118,22 @@ public class TripScheduleService {
                 .collect(Collectors.toList());
     }
 
-    // 여행 일정 삭제
+    // 로그인 한 회원의 개인 여행 일정 삭제
     @Transactional
-    public void deleteSchedule(Long scheduleId) {
+    public void deleteSchedule(Long scheduleId,
+                               String token) {
+
+        // 로그인한 회원 ID 가져오기
+        Member member = getLoggedInMemberId(token);
+
         TripSchedule schedule = tripScheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new ServiceException("404-1", "해당 일정이 존재하지 않습니다."));
+                .orElseThrow(() -> new ServiceException("404-1", "일정이 존재하지 않습니다."));
+
+        // 현재 로그인한 사용자가 일정 생성자인지 확인
+        if (!schedule.getMember().getId().equals(member.getId())) {
+            throw new ServiceException("403-1", "본인이 생성한 일정만 삭제할 수 있습니다.");
+        }
+
         tripScheduleRepository.delete(schedule);
     }
 

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
@@ -174,8 +174,8 @@ public class TripScheduleService {
                 .orElseThrow(() -> new ServiceException("404-1", "해당 일정이 존재하지 않습니다."));
 
         // 현재 로그인한 사용자가 일정 생성자인지 확인
-        if (!tripSchedule.getMember().getId().equals(member.getId())){
-            throw new ServiceException("403-1","본인이 생성한 일정만 수정할 수 있습니다.");
+        if (!tripSchedule.getMember().getId().equals(member.getId())) {
+            throw new ServiceException("403-1", "본인이 생성한 일정만 수정할 수 있습니다.");
         }
 
         // 여행 일정 수정
@@ -202,10 +202,13 @@ public class TripScheduleService {
 
     // 특정 회원이 생성한 여행 일정 조회
     @Transactional(readOnly = true)
-    public List<TripScheduleResDto> getSchedulesByCreator(Long memberId) {
+    public List<TripScheduleResDto> getSchedulesByCreator(String token) {
+
+        // 로그인한 회원 정보 가져오기
+        Member member = getLoggedInMember(token);
 
         // 회원 ID를 기반으로 해당 회원이 만든 여행 일정들을 조회
-        List<TripSchedule> schedules = tripScheduleRepository.findByMemberId(memberId);
+        List<TripSchedule> schedules = tripScheduleRepository.findByMemberId(member.getId());
 
         // 여행 일정이 존재하지 않는 경우 예외 발생
         if (schedules.isEmpty()) {

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
@@ -149,6 +149,24 @@ public class TripScheduleService {
 
         return new TripUpdateResDto(tripSchedule, updatedTripInformations);
     }
+
+    // 특정 회원이 생성한 여행 일정 조회
+    @Transactional(readOnly = true)
+    public List<TripScheduleResDto> getSchedulesByCreator(Long memberId) {
+
+        // 회원 ID를 기반으로 해당 회원이 만든 여행 일정들을 조회
+        List<TripSchedule> schedules = tripScheduleRepository.findByMemberId(memberId);
+
+        // 여행 일정이 존재하지 않는 경우 예외 발생
+        if (schedules.isEmpty()) {
+            throw new ServiceException("404-3", "해당 회원의 여행 일정이 존재하지 않습니다.");
+        }
+
+        // 조회한 TripSchedule 엔티티 리스트를 TripScheduleResDto 리스트로 변환하여 반환
+        return schedules.stream()
+                .map(TripScheduleResDto::new)
+                .collect(Collectors.toList());
+    }
 }
 
 

--- a/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
+++ b/backend/src/main/java/com/tripfriend/domain/trip/schedule/service/TripScheduleService.java
@@ -2,6 +2,7 @@ package com.tripfriend.domain.trip.schedule.service;
 
 import com.tripfriend.domain.member.member.entity.Member;
 import com.tripfriend.domain.member.member.repository.MemberRepository;
+import com.tripfriend.domain.member.member.service.AuthService;
 import com.tripfriend.domain.place.place.entity.Place;
 import com.tripfriend.domain.place.place.repository.PlaceRepository;
 import com.tripfriend.domain.trip.information.dto.TripInformationUpdateReqDto;
@@ -28,16 +29,33 @@ public class TripScheduleService {
     private final MemberRepository memberRepository;
     private final TripInformationService tripInformationService;
     private final TripInformationRepository tripInformationRepository;
+    private final AuthService authService;
     private final PlaceRepository placeRepository;
+
+    /**
+     * 현재 로그인한 회원객체를 반환하는 메서드
+     *
+     * @param token JWT 토큰
+     * @return 로그인한 회원 객체
+     * @throws ServiceException 로그인하지 않은 경우 예외 발생
+     */
+    public Member getLoggedInMemberId(String token) {
+        // 로그인 여부 확인 및 회원 정보 가져오기
+        Member member = authService.getLoggedInMember(token);
+
+        if (member == null) {
+            throw new ServiceException("401-1", "로그인이 필요합니다.");
+        }
+
+        return member;
+    }
 
     // 여행 일정 생성
     @Transactional
-    public TripScheduleResDto createSchedule(TripScheduleReqDto req) {
+    public TripScheduleResDto createSchedule(TripScheduleReqDto req, String token) {
 
         // 회원 확인
-        Member member = memberRepository.findById(req.getMemberId()).orElseThrow(
-                () -> new ServiceException("404-1", "해당 회원이 존재하지 않습니다.")
-        );
+        Member member = getLoggedInMemberId(token);
 
         // 여행 일정 생성 및 저장
         TripSchedule newSchedule = TripSchedule.builder()
@@ -57,7 +75,7 @@ public class TripScheduleService {
         return new TripScheduleResDto(newSchedule);
     }
 
-    // 전체 일정 조회
+    // 전체 일정 조회(필요없을듯)
     @Transactional(readOnly = true)
     public List<TripScheduleResDto> getAllSchedules() {
         List<TripSchedule> schedules = tripScheduleRepository.findAll();

--- a/backend/src/main/java/com/tripfriend/global/aspect/ResponseAspect.java
+++ b/backend/src/main/java/com/tripfriend/global/aspect/ResponseAspect.java
@@ -1,0 +1,48 @@
+package com.tripfriend.global.aspect;
+
+import com.tripfriend.global.dto.RsData;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ResponseAspect {
+
+    private final HttpServletResponse response;
+
+    @Around("""
+            (
+                within
+                (
+                    @org.springframework.web.bind.annotation.RestController *
+                )
+                &&
+                (
+                    @annotation(org.springframework.web.bind.annotation.GetMapping)
+                    ||
+                    @annotation(org.springframework.web.bind.annotation.PostMapping)
+                    ||
+                    @annotation(org.springframework.web.bind.annotation.PutMapping)
+                    ||
+                    @annotation(org.springframework.web.bind.annotation.DeleteMapping)
+                )
+            )
+            ||
+            @annotation(org.springframework.web.bind.annotation.ResponseBody)
+            """)
+    public Object responseAspect(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object rst = joinPoint.proceed();
+
+        if (rst instanceof RsData rsData) {
+            int statusCode = rsData.getStatusCode();
+            response.setStatus(statusCode);
+        }
+
+        return rst;
+    }
+}

--- a/backend/src/main/java/com/tripfriend/global/dto/RsData.java
+++ b/backend/src/main/java/com/tripfriend/global/dto/RsData.java
@@ -1,5 +1,6 @@
 package com.tripfriend.global.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,6 +23,8 @@ public class RsData<T> {
         this(code, msg, null);
     }
 
+    // StatusCode가 Json 포함 되지 않는다.
+    @JsonIgnore
     public int getStatusCode(){
         String statusCodeStr = code.split("-")[0];
         return Integer.parseInt(statusCodeStr);


### PR DESCRIPTION
## 🔎 작업 내용

- 여행지, 여행 일정 Swagger API 설명 추가

- 여행지 도메인 리팩토링
   - controller에 적용되어 있던 비즈니스 로직을 Service로 보내 역할 구분을 명확하게 함

- ResponseAspect를 추가
   - Spring AOP를 활용하여 컨트롤러에서 반환하는 RsData 객체의 상태 코드가 HTTP 응답 코드로 자동 설정
   - ResponseAspect Class로 HTTP 응답 코드가 자동 설정 되기 때문에 StatusCode가 Json에 포함되지 않도록 설정

- 여행 일정 도메인 리팩토링
   - 로그인 한 회원 기준으로 여행 일정 도메인을 사용할 수 있도록 수정
   - 로그인 한 회원은 나의 여행일정을 등록, 조회, 삭제, 수정 가능
  <br/>

## ➕ 이슈 링크
- [GODAOS/re-66 #66](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team10/issues/66)

<br/>

<!-- closed #66 -->
