### PR TITLE
feat(72) : 여행지 목록, 여행지 세부 정보 레이아웃 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -69,6 +69,7 @@ def generated = 'src/main/generated'
 // querydsl QClass 파일 생성 위치를 지정
 tasks.withType(JavaCompile) {
 	options.getGeneratedSourceOutputDirectory().set(file(generated))
+	options.compilerArgs << "-parameters" // 여기 부분 추가
 }
 
 // java source set 에 querydsl QClass 위치 추가

--- a/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
@@ -12,7 +12,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -26,8 +31,26 @@ public class PlaceController {
     // 여행지 등록
     @PostMapping
     @Operation(summary = "여행지 등록")
-    public RsData<PlaceResDto> createPlace(@RequestBody PlaceCreateReqDto req) {
-        Place savePlace = placeService.createPlace(req);
+    public RsData<PlaceResDto> createPlace(@RequestBody PlaceCreateReqDto req,
+                                           @RequestParam("image")MultipartFile image) throws IOException {
+
+        String fileName = null;
+
+        if (!image.isEmpty()) {
+            String uploadDir = "src/main/resources/static/";
+            File uploadDirFile = new File(uploadDir);
+
+            if (!uploadDirFile.exists()) {
+                uploadDirFile.mkdirs();
+            }
+
+            fileName = image.getOriginalFilename();
+            Path filePath = Paths.get(uploadDir + fileName);
+
+            image.transferTo(filePath);
+        }
+
+        Place savePlace = placeService.createPlace(req, fileName);
         PlaceResDto placeResDto = new PlaceResDto(savePlace);
         return new RsData<>(
                 "200-1",

--- a/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
@@ -7,7 +7,9 @@ import com.tripfriend.domain.place.place.entity.Place;
 import com.tripfriend.domain.place.place.service.PlaceService;
 import com.tripfriend.global.dto.RsData;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -50,7 +52,8 @@ public class PlaceController {
     // 특정 여행지 조회 - 단건 조회
     @GetMapping("/{id}")
     @Operation(summary = "여행지 조회")
-    public RsData<PlaceResDto> getPlace(@PathVariable Long id) {
+    public RsData<PlaceResDto> getPlace(@Parameter(description = "여행지 ID", required = true, example = "1")
+                                        @PathVariable Long id) {
         Place place = placeService.getPlace(id);
         PlaceResDto placeResDto = new PlaceResDto(place);
         return new RsData<>(
@@ -63,7 +66,8 @@ public class PlaceController {
     // 특정 여행지 삭제
     @DeleteMapping("/{id}")
     @Operation(summary = "여행지 삭제")
-    public RsData<Void> deletePlace(@PathVariable Long id) {
+    public RsData<Void> deletePlace(@Parameter(description = "여행지 ID", required = true, example = "1")
+                                    @PathVariable Long id) {
         Place place = placeService.getPlace(id);
         placeService.deletePlace(place);
         return new RsData<>(
@@ -75,7 +79,9 @@ public class PlaceController {
     // 특정 여행지 정보 수정
     @PutMapping("/{id}")
     @Operation(summary = "여행지 정보 수정")
-    public RsData<PlaceResDto> updatePlace(@PathVariable Long id, @RequestBody PlaceUpdateReqDto placeUpdateReqDto) {
+    public RsData<PlaceResDto> updatePlace(@Parameter(description = "여행지 ID", required = true, example = "1")
+                                           @PathVariable Long id,
+                                           @RequestBody PlaceUpdateReqDto placeUpdateReqDto) {
         Place place = placeService.getPlace(id);
         Place updatePlace = placeService.updatePlace(place, placeUpdateReqDto);
         PlaceResDto placeResDto = new PlaceResDto(updatePlace);

--- a/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
@@ -36,6 +36,7 @@ public class PlaceController {
 
         String fileName = null;
 
+        // 이미지 처리
         if (!image.isEmpty()) {
             String uploadDir = "src/main/resources/static/";
             File uploadDirFile = new File(uploadDir);
@@ -50,7 +51,7 @@ public class PlaceController {
             image.transferTo(filePath);
         }
 
-        Place savePlace = placeService.createPlace(req, fileName);
+        Place savePlace = placeService.createPlace(req);
         PlaceResDto placeResDto = new PlaceResDto(savePlace);
         return new RsData<>(
                 "200-1",

--- a/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
@@ -9,15 +9,8 @@ import com.tripfriend.global.dto.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -31,25 +24,7 @@ public class PlaceController {
     // 여행지 등록
     @PostMapping
     @Operation(summary = "여행지 등록")
-    public RsData<PlaceResDto> createPlace(@RequestBody PlaceCreateReqDto req,
-                                           @RequestParam("image")MultipartFile image) throws IOException {
-
-        String fileName = null;
-
-        // 이미지 처리
-        if (!image.isEmpty()) {
-            String uploadDir = "src/main/resources/static/";
-            File uploadDirFile = new File(uploadDir);
-
-            if (!uploadDirFile.exists()) {
-                uploadDirFile.mkdirs();
-            }
-
-            fileName = image.getOriginalFilename();
-            Path filePath = Paths.get(uploadDir + fileName);
-
-            image.transferTo(filePath);
-        }
+    public RsData<PlaceResDto> createPlace(@RequestBody PlaceCreateReqDto req) {
 
         Place savePlace = placeService.createPlace(req);
         PlaceResDto placeResDto = new PlaceResDto(savePlace);

--- a/backend/src/main/java/com/tripfriend/domain/place/place/entity/Place.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/entity/Place.java
@@ -44,9 +44,9 @@ public class Place {
     private List<Recruit> recruits;
 
     // 후기 게시글 1:N 연결
-    @OneToMany(mappedBy = "place", cascade = CascadeType.REMOVE)
-    @JsonIgnore
-    private List<Review> reviews;
+//    @OneToMany(mappedBy = "place", cascade = CascadeType.REMOVE)
+//    @JsonIgnore
+//    private List<Review> reviews;
 
     @Column(name = "city_name", nullable = false)
     private String cityName; // 도시명

--- a/backend/src/main/java/com/tripfriend/domain/place/place/entity/Place.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/entity/Place.java
@@ -44,9 +44,9 @@ public class Place {
     private List<Recruit> recruits;
 
     // 후기 게시글 1:N 연결
-//    @OneToMany(mappedBy = "place", cascade = CascadeType.REMOVE)
-//    @JsonIgnore
-//    private List<Review> reviews;
+    @OneToMany(mappedBy = "place", cascade = CascadeType.REMOVE)
+    @JsonIgnore
+    private List<Review> reviews;
 
     @Column(name = "city_name", nullable = false)
     private String cityName; // 도시명

--- a/backend/src/main/java/com/tripfriend/domain/place/place/entity/Place.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/entity/Place.java
@@ -1,7 +1,8 @@
 package com.tripfriend.domain.place.place.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.tripfriend.domain.recruit.recruit.entity.Recruit;
+import com.tripfriend.domain.review.entity.Review;
 import com.tripfriend.domain.trip.information.entity.TripInformation;
 import jakarta.persistence.*;
 import lombok.*;
@@ -32,6 +33,16 @@ public class Place {
     @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnore
     private List<TripInformation> tripInformations = new ArrayList<>();
+
+    // 동행 게시글 1:N 연결
+    @OneToMany(mappedBy = "place", cascade = CascadeType.REMOVE)
+    @JsonIgnore
+    private List<Recruit> recruits;
+
+    // 후기 게시글 1:N 연결
+    @OneToMany(mappedBy = "place", cascade = CascadeType.REMOVE)
+    @JsonIgnore
+    private List<Review> reviews;
 
     @Column(name = "city_name", nullable = false)
     private String cityName; // 도시명

--- a/backend/src/main/java/com/tripfriend/domain/place/place/entity/Place.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/entity/Place.java
@@ -34,6 +34,10 @@ public class Place {
     @JsonIgnore
     private List<TripInformation> tripInformations = new ArrayList<>();
 
+    // 이미지 저장 URL
+    @Column(name = "image_url")
+    private String imageUrl;
+
     // 동행 게시글 1:N 연결
     @OneToMany(mappedBy = "place", cascade = CascadeType.REMOVE)
     @JsonIgnore

--- a/backend/src/main/java/com/tripfriend/domain/place/place/entity/Place.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/entity/Place.java
@@ -40,9 +40,9 @@ public class Place {
     private List<Recruit> recruits;
 
     // 후기 게시글 1:N 연결
-    @OneToMany(mappedBy = "place", cascade = CascadeType.REMOVE)
-    @JsonIgnore
-    private List<Review> reviews;
+//    @OneToMany(mappedBy = "place", cascade = CascadeType.REMOVE)
+//    @JsonIgnore
+//    private List<Review> reviews;
 
     @Column(name = "city_name", nullable = false)
     private String cityName; // 도시명

--- a/backend/src/main/java/com/tripfriend/domain/place/place/service/PlaceService.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/service/PlaceService.java
@@ -19,13 +19,12 @@ public class PlaceService {
     private final PlaceRepository placeRepository;
 
     // 여행 장소 등록
-    public Place createPlace(PlaceCreateReqDto req, String fileName) {
+    public Place createPlace(PlaceCreateReqDto req) {
         Place place = Place.builder()
                 .cityName(req.getCityName())
                 .placeName(req.getPlaceName())
                 .description(req.getDescription())
                 .category(req.getCategory())
-                .imageUrl("http://localhost:8080/"+fileName)
                 .build();
         placeRepository.save(place);
 

--- a/backend/src/main/java/com/tripfriend/domain/place/place/service/PlaceService.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/service/PlaceService.java
@@ -19,8 +19,14 @@ public class PlaceService {
     private final PlaceRepository placeRepository;
 
     // 여행 장소 등록
-    public Place createPlace(PlaceCreateReqDto req) {
-        Place place = req.toEntity();
+    public Place createPlace(PlaceCreateReqDto req, String fileName) {
+        Place place = Place.builder()
+                .cityName(req.getCityName())
+                .placeName(req.getPlaceName())
+                .description(req.getDescription())
+                .category(req.getCategory())
+                .imageUrl("http://localhost:8080/"+fileName)
+                .build();
         placeRepository.save(place);
 
         return place;

--- a/backend/src/main/java/com/tripfriend/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/tripfriend/global/security/SecurityConfig.java
@@ -28,7 +28,6 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 적용
                 .csrf(csrf -> csrf.disable())
                 // H2 콘솔 접근을 허용하기 위해 frameOptions 비활성화
                 .headers(headers -> headers.frameOptions(frame -> frame.disable()))

--- a/backend/src/main/java/com/tripfriend/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/tripfriend/global/security/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 적용
                 .csrf(csrf -> csrf.disable())
                 // H2 콘솔 접근을 허용하기 위해 frameOptions 비활성화
                 .headers(headers -> headers.frameOptions(frame -> frame.disable()))

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,18 +3,19 @@ import { useState } from "react";
 import Link from "next/link";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import Place from "./place/ClientPage"; // 여행지 조회
 
 export default function Home() {
   const [searchQuery, setSearchQuery] = useState("");
   const [destination, setDestination] = useState("");
 
-  // 인기 여행지 데이터
-  const popularDestinations = [
-    { id: 1, name: "제주도", image: "/placeholder.jpg", tripCount: 243 },
-    { id: 2, name: "방콕", image: "/placeholder.jpg", tripCount: 187 },
-    { id: 3, name: "오사카", image: "/placeholder.jpg", tripCount: 156 },
-    { id: 4, name: "파리", image: "/placeholder.jpg", tripCount: 142 },
-  ];
+  // // 인기 여행지 데이터
+  // const popularDestinations = [
+  //   { id: 1, name: "제주도", image: "/placeholder.jpg", tripCount: 243 },
+  //   { id: 2, name: "방콕", image: "/placeholder.jpg", tripCount: 187 },
+  //   { id: 3, name: "오사카", image: "/placeholder.jpg", tripCount: 156 },
+  //   { id: 4, name: "파리", image: "/placeholder.jpg", tripCount: 142 },
+  // ];
 
   // 최근 등록된 여행 동행 데이터
   const recentTrips = [
@@ -101,33 +102,8 @@ export default function Home() {
 
       {/* 인기 여행지 섹션 */}
       <div className="container mx-auto px-4 py-12">
-        <h3 className="text-2xl font-bold mb-6">인기 여행지</h3>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-          {popularDestinations.map((dest) => (
-            <div
-              key={dest.id}
-              className="bg-white rounded-lg shadow-md overflow-hidden"
-            >
-              <img
-                src={dest.image}
-                alt={dest.name}
-                className="w-full h-40 object-cover"
-              />
-              <div className="p-4">
-                <h4 className="text-xl font-semibold mb-2">{dest.name}</h4>
-                <p className="text-gray-600">
-                  현재 {dest.tripCount}개의 여행이 계획되어 있습니다
-                </p>
-                <Link
-                  href={`/destination/${dest.id}`}
-                  className="mt-3 inline-block text-blue-600 hover:underline"
-                >
-                  여행 둘러보기
-                </Link>
-              </div>
-            </div>
-          ))}
-        </div>
+        {/* <h3 className="text-2xl font-bold mb-6">인기 여행지</h3> */}
+        <Place />
       </div>
 
       {/* 최근 등록된 여행 동행 */}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -59,7 +59,10 @@ export default function Home() {
         <div className="container mx-auto px-4 py-16 md:py-24">
           <div className="max-w-2xl">
             <h2 className="text-3xl md:text-5xl font-bold mb-6">
-              혼자 떠나는 여행, 함께할 동행을 찾아보세요
+              혼자 떠나는 여행
+            </h2>
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              함께할 동행을 찾아보세요
             </h2>
             <p className="text-xl mb-8">
               전 세계 여행자들과 함께하는 특별한 여행 경험을 만들어보세요.

--- a/frontend/src/app/place/ClientPage.tsx
+++ b/frontend/src/app/place/ClientPage.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Place {
+  id: number;
+  cityName: string;
+  placeName: string;
+  description: string;
+  category: string;
+  image: string;
+}
+
+export default function ClientPage() {
+  const [places, setPlaces] = useState<Place[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedCity, setSelectedCity] = useState<string>("");
+  const [selectedCategory, setSelectedCategory] = useState<string>("");
+
+  useEffect(() => {
+    fetch("http://localhost:8080/place") // 백엔드 API 호출
+      .then((res) => res.json())
+      .then((data) => {
+        if (data && data.data) {
+          setPlaces(data.data); // 여행지 목록 저장
+        }
+      })
+      .catch((error) => console.error("Error fetching places:", error))
+      .finally(() => setLoading(false));
+  }, []);
+
+  // 선택된 CityName이 있는 경우 필터링된 데이터 반환
+  const filteredPlaces = places.filter(
+    (place) =>
+      (!selectedCity || place.cityName === selectedCity) &&
+      (!selectedCategory || place.category === selectedCategory)
+  );
+
+  if (loading) {
+    return <p>여행지 데이터를 불러오는 중...</p>;
+  }
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">전체 여행지</h2>
+
+      {/* 여행지 필터링 */}
+      <div className="flex gap-4 mb-4">
+        <select
+          value={selectedCity}
+          onChange={(e) => setSelectedCity(e.target.value)}
+          className="p-2 border rounded-md"
+        >
+          <option value="">모든 도시</option>
+          {Array.from(new Set(places.map((place) => place.cityName))).map(
+            (city) => (
+              <option key={city} value={city}>
+                {city}
+              </option>
+            )
+          )}
+        </select>
+
+        <select
+          value={selectedCategory}
+          onChange={(e) => setSelectedCategory(e.target.value)}
+          className="p-2 border rounded-md"
+        >
+          <option value="">모든 카테고리</option>
+          {Array.from(new Set(places.map((place) => place.category))).map(
+            (category) => (
+              <option key={category} value={category}>
+                {category}
+              </option>
+            )
+          )}
+        </select>
+      </div>
+
+      {/* 여행지 리스트 */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {filteredPlaces.map((place) => (
+          <div key={place.id} className="bg-white rounded-lg shadow-md p-4">
+            <img
+              src={place.image || "/default-placeholder.jpg"} // ✅ 이미지 추가
+              alt={place.cityName}
+              className="w-full h-40 object-cover rounded-md"
+            />
+            <h3 className="text-xl font-semibold mt-2">{place.placeName}</h3>
+            <p className="text-gray-600">{place.description}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/place/ClientPage.tsx
+++ b/frontend/src/app/place/ClientPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 
 interface Place {
   id: number;
@@ -16,6 +17,7 @@ export default function ClientPage() {
   const [loading, setLoading] = useState(true);
   const [selectedCity, setSelectedCity] = useState<string>("");
   const [selectedCategory, setSelectedCategory] = useState<string>("");
+  const router = useRouter(); // useRouter 함수 호출
 
   useEffect(() => {
     fetch("http://localhost:8080/place") // 백엔드 API 호출
@@ -78,19 +80,34 @@ export default function ClientPage() {
       </div>
 
       {/* 여행지 리스트 */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {filteredPlaces.map((place) => (
-          <div key={place.id} className="bg-white rounded-lg shadow-md p-4">
-            <img
-              src={place.image || "/default-placeholder.jpg"} // ✅ 이미지 추가
-              alt={place.cityName}
-              className="w-full h-40 object-cover rounded-md"
-            />
-            <h3 className="text-xl font-semibold mt-2">{place.placeName}</h3>
-            <p className="text-gray-600">{place.description}</p>
-          </div>
-        ))}
-      </div>
+      {filteredPlaces.length === 0 ? (
+        <p className="text-gray-500">해당 조건에 맞는 여행지가 없습니다.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filteredPlaces.map((place) => (
+            <div
+              key={place.id}
+              className="bg-white rounded-lg shadow-md p-4 cursor-pointer"
+            >
+              {/* 이미지 클릭 시 이동 */}
+              <img
+                src={place.image || "/default-placeholder.jpg"}
+                alt={place.cityName}
+                className="w-full h-40 object-cover rounded-md cursor-pointer"
+                onClick={() => router.push(`/place/${place.id}`)}
+              />
+              {/* 장소명 클릭 시 이동 */}
+              <h3
+                className="text-xl font-semibold mt-2 text-blue-500 cursor-pointer"
+                onClick={() => router.push(`/place/${place.id}`)}
+              >
+                {place.placeName}
+              </h3>
+              <p className="text-gray-600">{place.description}</p>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/place/[id]/ClientPage.tsx
+++ b/frontend/src/app/place/[id]/ClientPage.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
+
+interface Place {
+  id: number;
+  cityName: string;
+  placeName: string;
+  description: string;
+  category: string;
+  image: string;
+}
+
+export default function PlaceDetailPage() {
+  const { id } = useParams(); // URL에서 id 가져오기
+  const [place, setPlace] = useState<Place | null>(null);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!id) return;
+
+    fetch(`http://localhost:8080/place/${id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data && data.data) {
+          setPlace(data.data);
+        }
+      })
+      .catch((error) => console.error("Error fetching place details:", error))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) {
+    return <p>여행지 정보를 불러오는 중...</p>;
+  }
+
+  if (!place) {
+    return <p>해당 여행지를 찾을 수 없습니다.</p>;
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <button className="mb-4 text-blue-500" onClick={() => router.back()}>
+        뒤로가기
+      </button>
+      <h1 className="text-3xl font-bold mb-4">{place.placeName}</h1>
+      <img
+        src={place.image || "/default-placeholder.jpg"}
+        alt={place.placeName}
+        className="w-full h-64 object-cover rounded-md"
+      />
+      <p className="mt-4 text-gray-700">{place.description}</p>
+      <p className="mt-2 text-sm text-gray-500">도시: {place.cityName}</p>
+      <p className="mt-2 text-sm text-gray-500">카테고리: {place.category}</p>
+    </div>
+  );
+}

--- a/frontend/src/app/place/[id]/page.tsx
+++ b/frontend/src/app/place/[id]/page.tsx
@@ -1,0 +1,15 @@
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import ClientPage from "./ClientPage";
+
+export default async function Page() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-grow">
+        <ClientPage />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/app/place/page.tsx
+++ b/frontend/src/app/place/page.tsx
@@ -1,0 +1,5 @@
+import ClientPage from "./ClientPage";
+
+export default async function Page() {
+  return <ClientPage />;
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 전체 여행지 리스트 출력

- 여행지 swagger에 파라미터 값 입력 가능, 등록 및 삭제, 수정

- 여행 리스트의 사진 및 이름 클릭시 여행정보 페이지로 이동

  <br/>

![image](https://github.com/user-attachments/assets/ce9401c2-66c6-4d27-b335-9db68c2a6a28)




## ➕ 이슈 링크
- [GODAOS/fe/feat-72 #72]

<br/>

<!-- closed #72 -->
