### PR TITLE
feat(98): 사용자 인증 로직 수정

### DIFF
--- a/backend/src/main/java/com/tripfriend/domain/review/controller/CommentController.java
+++ b/backend/src/main/java/com/tripfriend/domain/review/controller/CommentController.java
@@ -1,11 +1,14 @@
 package com.tripfriend.domain.review.controller;
 
 import com.tripfriend.domain.member.member.entity.Member;
+import com.tripfriend.domain.member.member.service.AuthService;
 import com.tripfriend.domain.member.member.repository.MemberRepository;
 import com.tripfriend.domain.review.dto.CommentRequestDto;
 import com.tripfriend.domain.review.dto.CommentResponseDto;
 import com.tripfriend.domain.review.service.CommentService;
 import com.tripfriend.global.dto.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import com.tripfriend.global.exception.ServiceException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -13,32 +16,31 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Comment API", description = "댓글 관련 기능을 제공합니다.")
 @RestController
 @RequestMapping("/api/comments")
 @RequiredArgsConstructor
 public class CommentController {
 
     private final CommentService commentService;
-    private final MemberRepository memberRepository;
-
-    // 임시 회원 조회 - 실제 인증 시스템으로 대체 예정
-    private Member getMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new ServiceException("404-2", "회원을 찾을 수 없습니다."));
-    }
+    private final AuthService authService;
 
     // 댓글 생성
+    @Operation(summary = "댓글 생성")
     @PostMapping
     public RsData<CommentResponseDto> createComment(
             @Valid @RequestBody CommentRequestDto requestDto,
-            @RequestParam(name = "memberId",defaultValue = "1") Long memberId) {
-        // 임시 인증 로직
-        Member member = getMemberById(memberId);
-        CommentResponseDto responseDto = commentService.createComment(requestDto, member);
+            @RequestHeader(value = "Authorization", required = false) String token) {
+
+        // 토큰에서 인증된 사용자 정보 가져오기
+        Member loggedInMember = authService.getLoggedInMember(token);
+
+        CommentResponseDto responseDto = commentService.createComment(requestDto, loggedInMember);
         return new RsData<>("201-1", "댓글이 성공적으로 등록되었습니다.", responseDto);
     }
 
     // 댓글 상세 조회
+    @Operation(summary = "댓글 상세 조회")
     @GetMapping("/{commentId}")
     public RsData<CommentResponseDto> getComment(@PathVariable("commentId") Long commentId) {
         CommentResponseDto responseDto = commentService.getComment(commentId);
@@ -46,41 +48,52 @@ public class CommentController {
     }
 
     // 특정 리뷰의 댓글 목록 조회
+    @Operation(summary = "특정 리뷰의 댓글 목록 조회")
     @GetMapping("/review/{reviewId}")
     public RsData<List<CommentResponseDto>> getCommentsByReview(@PathVariable("reviewId") Long reviewId) {
         List<CommentResponseDto> responseDtoList = commentService.getCommentsByReview(reviewId);
         return new RsData<>("200-2", "리뷰의 댓글 목록을 성공적으로 조회했습니다.", responseDtoList);
     }
 
-    // 특정 회원의 댓글 목록 조회
-    @GetMapping("/member/{memberId}")
-    public RsData<List<CommentResponseDto>> getCommentsByMember(@PathVariable("memberId") Long memberId) {
-        List<CommentResponseDto> responseDtoList = commentService.getCommentsByMember(memberId);
-        return new RsData<>("200-3", "회원의 댓글 목록을 성공적으로 조회했습니다.", responseDtoList);
+    // 내가 작성한 댓글 목록 조회
+    @Operation(summary = "내가 작성한 댓글 목록 조회")
+    @GetMapping("/my")
+    public RsData<List<CommentResponseDto>> getMyComments(
+            @RequestHeader(value = "Authorization", required = false) String token) {
+
+        // 토큰에서 인증된 사용자 정보 가져오기
+        Member loggedInMember = authService.getLoggedInMember(token);
+
+        List<CommentResponseDto> responseDtoList = commentService.getCommentsByMember(loggedInMember.getId());
+        return new RsData<>("200-3", "내 댓글 목록을 성공적으로 조회했습니다.", responseDtoList);
     }
 
     // 댓글 수정
+    @Operation(summary = "댓글 수정")
     @PutMapping("/{commentId}")
     public RsData<CommentResponseDto> updateComment(
             @PathVariable("commentId") Long commentId,
             @Valid @RequestBody CommentRequestDto requestDto,
-            @RequestParam(name = "memberId",defaultValue = "1") Long memberId) {
+            @RequestHeader(value = "Authorization", required = false) String token) {
 
-        // 임시 인증 로직
-        Member member = getMemberById(memberId);
-        CommentResponseDto responseDto = commentService.updateComment(commentId, requestDto, member);
+        // 토큰에서 인증된 사용자 정보 가져오기
+        Member loggedInMember = authService.getLoggedInMember(token);
+
+        CommentResponseDto responseDto = commentService.updateComment(commentId, requestDto, loggedInMember);
         return new RsData<>("200-4", "댓글이 성공적으로 수정되었습니다.", responseDto);
     }
 
     // 댓글 삭제
+    @Operation(summary = "댓글 삭제")
     @DeleteMapping("/{commentId}")
     public RsData<Void> deleteComment(
             @PathVariable("commentId") Long commentId,
-            @RequestParam(name = "memberId", defaultValue = "1") Long memberId) {
+            @RequestHeader(value = "Authorization", required = false) String token) {
 
-        // 임시 인증 로직
-        Member member = getMemberById(memberId);
-        commentService.deleteComment(commentId, member);
+        // 토큰에서 인증된 사용자 정보 가져오기
+        Member loggedInMember = authService.getLoggedInMember(token);
+
+        commentService.deleteComment(commentId, loggedInMember);
         return new RsData<>("200-5", "댓글이 성공적으로 삭제되었습니다.");
     }
 }

--- a/backend/src/main/java/com/tripfriend/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/tripfriend/domain/review/controller/ReviewController.java
@@ -1,48 +1,50 @@
 package com.tripfriend.domain.review.controller;
 
 import com.tripfriend.domain.member.member.entity.Member;
+import com.tripfriend.domain.member.member.service.AuthService;
 import com.tripfriend.domain.member.member.repository.MemberRepository;
 import com.tripfriend.domain.review.dto.ReviewRequestDto;
 import com.tripfriend.domain.review.dto.ReviewResponseDto;
 import com.tripfriend.domain.review.service.ReviewService;
 import com.tripfriend.global.dto.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import com.tripfriend.global.exception.ServiceException;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+@Tag(name = "Review API", description = "리뷰 관련 기능을 제공합니다.")
 @RestController
 @RequestMapping("/api/reviews")
 @RequiredArgsConstructor
 public class ReviewController {
 
     private final ReviewService reviewService;
-    private final MemberRepository memberRepository;
-
-    // 임시 회원 조회 - 실제 인증 시스템으로 대체 예정
-    private Member getMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new ServiceException("404-2", "회원을 찾을 수 없습니다."));
-    }
+    private final AuthService authService;
 
     // 리뷰 생성
+    @Operation(summary = "리뷰 생성")
     @PostMapping
     public RsData<ReviewResponseDto> createReview(
             @Valid @RequestBody ReviewRequestDto requestDto,
-            @RequestParam(name = "memberId", defaultValue = "1") Long memberId) {
+            @RequestHeader(value = "Authorization", required = false) String token) {
 
-        // 임시 인증 로직
-        Member member = getMemberById(memberId);
-        ReviewResponseDto responseDto = reviewService.createReview(requestDto, member);
+        // 토큰에서 인증된 사용자 정보 가져오기
+        Member loggedInMember = authService.getLoggedInMember(token);
+
+        ReviewResponseDto responseDto = reviewService.createReview(requestDto, loggedInMember);
         return new RsData<>("201-1", "리뷰가 성공적으로 등록되었습니다.", responseDto);
     }
 
     // 리뷰 상세 조회
+    @Operation(summary = "리뷰 상세 조회")
     @GetMapping("/{reviewId}")
     public RsData<ReviewResponseDto> getReview(
             @PathVariable("reviewId") Long reviewId,
@@ -65,6 +67,7 @@ public class ReviewController {
     }
 
     // 특정 장소의 리뷰 목록 조회
+    @Operation(summary = "특정 장소의 리뷰 목록 조회")
     @GetMapping("/place/{placeId}")
     public RsData<List<ReviewResponseDto>> getReviewsByPlace(@PathVariable("placeId") Long placeId) {
         List<ReviewResponseDto> responseDtoList = reviewService.getReviewsByPlace(placeId);
@@ -72,29 +75,38 @@ public class ReviewController {
     }
 
     // 리뷰 수정
+    @Operation(summary = "리뷰 수정")
     @PutMapping("/{reviewId}")
     public RsData<ReviewResponseDto> updateReview(
             @PathVariable("reviewId") Long reviewId,
             @Valid @RequestBody ReviewRequestDto requestDto,
-            @RequestParam(name = "memberId",defaultValue = "1") Long memberId){
-        // 임시 인증 로직
-        Member member = getMemberById(memberId);
-        ReviewResponseDto responseDto = reviewService.updateReview(reviewId, requestDto, member);
+            @RequestHeader(value = "Authorization", required = false) String token) {
+
+        // 토큰에서 인증된 사용자 정보 가져오기
+        Member loggedInMember = authService.getLoggedInMember(token);
+
+        ReviewResponseDto responseDto = reviewService.updateReview(reviewId, requestDto, loggedInMember);
         return new RsData<>("200-3", "리뷰가 성공적으로 수정되었습니다.", responseDto);
     }
 
+
     // 리뷰 삭제
+    @Operation(summary = "리뷰 삭제")
     @DeleteMapping("/{reviewId}")
     public RsData<Void> deleteReview(
             @PathVariable("reviewId") Long reviewId,
-            @RequestParam(name = "memberId", defaultValue = "1") Long memberId) {
-        // 임시 인증 로직
-        Member member = getMemberById(memberId);
-        reviewService.deleteReview(reviewId, member);
+            @RequestHeader(value = "Authorization", required = false) String token) {
+
+        // 토큰에서 인증된 사용자 정보 가져오기
+        Member loggedInMember = authService.getLoggedInMember(token);
+
+        reviewService.deleteReview(reviewId, loggedInMember);
         return new RsData<>("200-4", "리뷰가 성공적으로 삭제되었습니다.");
     }
 
+
     // 인기 게시물 조회
+    @Operation(summary = "인기 게시물 조회")
     @GetMapping("/popular")
     public RsData<List<ReviewResponseDto>> getPopularReviews(
             @RequestParam(name = "limit", defaultValue = "10") int limit) {
@@ -105,15 +117,45 @@ public class ReviewController {
 
 
     // 리뷰 목록 조회 (정렬 및 검색)
+    @Operation(summary = "리뷰 목록 조회 (정렬 및 검색)")
     @GetMapping
     public RsData<List<ReviewResponseDto>> getReviews(
             @RequestParam(name = "sort",defaultValue = "newest") String sort,
             @RequestParam(name = "keyword", required = false) String keyword,
             @RequestParam(name = "placeId", required = false) Long placeId,
-            @RequestParam(name = "memberId",required = false) Long memberId) {
+            @RequestHeader(value = "Authorization", required = false) String token) {
+
+        Long memberId = null;
+        // 토큰이 제공된 경우 사용자 리뷰 필터링을 위해 memberId 추출
+        if (token != null && !token.isEmpty()) {
+            Member loggedInMember = authService.getLoggedInMember(token);
+            memberId = loggedInMember.getId();
+        }
 
         List<ReviewResponseDto> reviews = reviewService.getReviews(sort, keyword, placeId, memberId);
         return new RsData<>("200-5", "리뷰 목록을 성공적으로 조회했습니다.", reviews);
     }
 
+    // 내가 작성한 리뷰 목록 조회
+    @Operation(summary = "내가 작성한 리뷰 목록 조회")
+    @GetMapping("/my")
+    public RsData<List<ReviewResponseDto>> getMyReviews(
+            @RequestHeader(value = "Authorization", required = false) String token) {
+
+        // 토큰에서 인증된 사용자 정보 가져오기
+        Member loggedInMember = authService.getLoggedInMember(token);
+
+        List<ReviewResponseDto> reviews = reviewService.getReviewsByMember(loggedInMember.getId());
+        return new RsData<>("200-7", "내 리뷰 목록을 성공적으로 조회했습니다.", reviews);
+    }
+
+    // 특정 회원의 리뷰 목록 조회
+    @Operation(summary = "특정 회원의 리뷰 목록 조회")
+    @GetMapping("/member/{memberId}")
+    public RsData<List<ReviewResponseDto>> getMemberReviews(
+            @PathVariable("memberId") Long memberId) {
+
+        List<ReviewResponseDto> reviews = reviewService.getReviewsByMember(memberId);
+        return new RsData<>("200-8", "회원의 리뷰 목록을 성공적으로 조회했습니다.", reviews);
+    }
 }


### PR DESCRIPTION

## 🔎 작업 내용

- memberId를 직접 받던 방식을 제거하고 JWT 토큰으로 변경
- 사용자 자신의 리뷰/댓글을 조회하는 전용 엔드포인트 추가
- 특정 사용자의 리뷰를 조회할 수 있는 엔드포인트 추가


  <br/>

<br/>

## ➕ 이슈 링크
-  #98 

<br/>

<!-- closed #98  -->
