### PR TITLE
feat(110) : 여행지 세부 조회 & 관리자 여행 등록 삭제 기능 구현

### DIFF
--- a/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
@@ -28,6 +28,7 @@ public class PlaceController {
 
     // 여행지 등록
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @CheckPermission("ADMIN") //관리자
     @Operation(summary = "여행지 등록", description = "새로운 여행지를 등록합니다.")
     public RsData<PlaceResDto> createPlace(@ModelAttribute PlaceCreateReqDto req) {
 
@@ -100,6 +101,7 @@ public class PlaceController {
 
     // 특정 여행지 삭제
     @DeleteMapping("/{id}")
+    @CheckPermission("ADMIN") //관리자
     @Operation(summary = "여행지 삭제", description = "특정 여행지를 삭제합니다.")
     public RsData<Void> deletePlace(@Parameter(description = "여행지 ID", required = true, example = "1")
                                     @PathVariable Long id) {

--- a/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/controller/PlaceController.java
@@ -5,12 +5,15 @@ import com.tripfriend.domain.place.place.dto.PlaceResDto;
 import com.tripfriend.domain.place.place.dto.PlaceUpdateReqDto;
 import com.tripfriend.domain.place.place.entity.Place;
 import com.tripfriend.domain.place.place.service.PlaceService;
+import com.tripfriend.global.annotation.CheckPermission;
 import com.tripfriend.global.dto.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,9 +27,9 @@ public class PlaceController {
     private final PlaceService placeService;
 
     // 여행지 등록
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "여행지 등록", description = "새로운 여행지를 등록합니다.")
-    public RsData<PlaceResDto> createPlace(@RequestBody(required = false) PlaceCreateReqDto req) {
+    public RsData<PlaceResDto> createPlace(@ModelAttribute PlaceCreateReqDto req) {
 
         Place savePlace = placeService.createPlace(req);
         PlaceResDto placeResDto = new PlaceResDto(savePlace);
@@ -52,6 +55,19 @@ public class PlaceController {
                 "200-2",
                 "전체 여행지가 성공적으로 조회되었습니다.",
                 placeResDtos
+        );
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "특정 여행지 조회", description = "특정 여행지를 조회합니다.")
+    public RsData<PlaceResDto> getPlace(@PathVariable Long id) {
+        Place place = placeService.getPlace(id);
+        PlaceResDto placeResDto = new PlaceResDto(place);
+
+        return new RsData<>(
+                "200-3",
+                "특정 여행지가 성공적으로 조회되었습니다.",
+                placeResDto
         );
     }
 

--- a/backend/src/main/java/com/tripfriend/domain/place/place/dto/PlaceCreateReqDto.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/dto/PlaceCreateReqDto.java
@@ -7,8 +7,11 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class PlaceCreateReqDto {
@@ -23,6 +26,8 @@ public class PlaceCreateReqDto {
 
     @NotNull(message = "카테고리를 선택해주세요")
     private Category category;
+
+    private MultipartFile imageUrl; // 단일 이미지
 
     // DTO -> Entity 변환
     public Place toEntity(){

--- a/backend/src/main/java/com/tripfriend/domain/place/place/dto/PlaceResDto.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/dto/PlaceResDto.java
@@ -18,7 +18,7 @@ public class PlaceResDto {
     private String placeName;
     private String description;
     private Category category;
-    private String imgeUrl;
+    private String imageUrl;
 
 
     public PlaceResDto(Place place) {
@@ -27,6 +27,6 @@ public class PlaceResDto {
         this.placeName = place.getPlaceName();
         this.description = place.getDescription();
         this.category = place.getCategory();
-        this.imgeUrl = place.getImageUrl();
+        this.imageUrl = place.getImageUrl();
     }
 }

--- a/backend/src/main/java/com/tripfriend/domain/place/place/dto/PlaceResDto.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/dto/PlaceResDto.java
@@ -18,7 +18,7 @@ public class PlaceResDto {
     private String placeName;
     private String description;
     private Category category;
-
+    private String imgeUrl;
 
 
     public PlaceResDto(Place place) {
@@ -27,5 +27,6 @@ public class PlaceResDto {
         this.placeName = place.getPlaceName();
         this.description = place.getDescription();
         this.category = place.getCategory();
+        this.imgeUrl = place.getImageUrl();
     }
 }

--- a/backend/src/main/java/com/tripfriend/domain/place/place/service/PlaceService.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/service/PlaceService.java
@@ -114,9 +114,6 @@ public class PlaceService {
     public String uploadPlaceImage(MultipartFile imageFile) throws IOException {
 
         String imageUrl = imageUtil.saveImage(imageFile);
-        if (imageUrl == null) {
-            throw new ServiceException("404-2", "이미지 업로드에 실패하였습니다.");
-        }
 
         return imageUrl;
     }

--- a/backend/src/main/java/com/tripfriend/domain/place/place/service/PlaceService.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/service/PlaceService.java
@@ -5,11 +5,16 @@ import com.tripfriend.domain.place.place.dto.PlaceResDto;
 import com.tripfriend.domain.place.place.dto.PlaceUpdateReqDto;
 import com.tripfriend.domain.place.place.entity.Place;
 import com.tripfriend.domain.place.place.repository.PlaceRepository;
+import com.tripfriend.global.annotation.CheckPermission;
 import com.tripfriend.global.exception.ServiceException;
+import com.tripfriend.global.util.ImageUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.rmi.ServerException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -18,17 +23,31 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class PlaceService {
     private final PlaceRepository placeRepository;
+    private final ImageUtil imageUtil;
 
     // 여행 장소 등록
+    @Transactional
     public Place createPlace(PlaceCreateReqDto req) {
+
+        String imageUrl = null;
+        MultipartFile imageFile = req.getImageUrl();
+
+        if (imageFile != null && !imageFile.isEmpty()) {
+            try {
+                imageUrl = uploadPlaceImage(imageFile);
+            } catch (IOException e) {
+                throw new ServiceException("404-2", "이미지 업로드에 실패했습니다.");
+            }
+        }
+
         Place place = Place.builder()
                 .cityName(req.getCityName())
                 .placeName(req.getPlaceName())
                 .description(req.getDescription())
                 .category(req.getCategory())
+                .imageUrl(imageUrl)
                 .build();
         placeRepository.save(place);
-
         return place;
     }
 
@@ -55,6 +74,7 @@ public class PlaceService {
     }
 
     // 여행 장소 삭제
+    @CheckPermission("ADMIN")
     @Transactional
     public void deletePlace(Place place) {
         placeRepository.delete(place);
@@ -89,4 +109,18 @@ public class PlaceService {
         return new ArrayList<>();
 
     }
+
+    // 여행지 이미지 등록
+    public String uploadPlaceImage(MultipartFile imageFile) throws IOException {
+
+        String imageUrl = imageUtil.saveImage(imageFile);
+//        if (imageUrl != null) {
+//            throw new ServiceException("404-2", "이미지 업로드에 실패하였습니다.");
+//        }
+
+        return imageUrl;
+    }
+
+    // 여행 이미지 삭제
+
 }

--- a/backend/src/main/java/com/tripfriend/domain/place/place/service/PlaceService.java
+++ b/backend/src/main/java/com/tripfriend/domain/place/place/service/PlaceService.java
@@ -114,13 +114,11 @@ public class PlaceService {
     public String uploadPlaceImage(MultipartFile imageFile) throws IOException {
 
         String imageUrl = imageUtil.saveImage(imageFile);
-//        if (imageUrl != null) {
-//            throw new ServiceException("404-2", "이미지 업로드에 실패하였습니다.");
-//        }
+        if (imageUrl == null) {
+            throw new ServiceException("404-2", "이미지 업로드에 실패하였습니다.");
+        }
 
         return imageUrl;
     }
-
-    // 여행 이미지 삭제
 
 }

--- a/frontend/public/default-placeholder.svg
+++ b/frontend/public/default-placeholder.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="400" height="200" fill="#f3f4f6"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#374151" font-size="20">
+    이미지 준비 중입니다.
+  </text>
+</svg>

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -14,7 +14,8 @@ export default function AdminPage() {
         <div className="container mx-auto px-4 text-center">
           <h1 className="text-4xl font-bold mb-4">TripFriend 관리자 페이지</h1>
           <p className="text-xl">
-            여행지, 게시글, 회원, 블랙리스트 등 서비스를 직접 관리할 수 있습니다.
+            여행지, 게시글, 회원, 블랙리스트 등 서비스를 직접 관리할 수
+            있습니다.
           </p>
         </div>
       </div>
@@ -24,7 +25,7 @@ export default function AdminPage() {
         <h2 className="text-2xl font-bold mb-8">관리 기능</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           <AdminCard title="게시글 관리" href="/admin/post" />
-          <AdminCard title="여행지 관리" href="/admin/travel" />
+          <AdminCard title="여행지 관리" href="/admin/place" />
           <AdminCard title="이벤트 관리" href="/admin/event" />
           <AdminCard title="공지사항 관리" href="/admin/notice" />
           <AdminCard title="회원 목록" href="/admin/users" />

--- a/frontend/src/app/admin/place/ClientPage.tsx
+++ b/frontend/src/app/admin/place/ClientPage.tsx
@@ -135,7 +135,7 @@ export default function ClientPage() {
                     : "/default-placeholder.jpg"
                 }
                 alt={place.cityName}
-                className="w-full h-40 object-cover rounded-md cursor-pointer"
+                className="w-full h-auto object-cover rounded-md cursor-pointer"
                 onClick={() => router.push(`/place/${place.id}`)}
               />
               <h3

--- a/frontend/src/app/admin/place/ClientPage.tsx
+++ b/frontend/src/app/admin/place/ClientPage.tsx
@@ -132,7 +132,7 @@ export default function ClientPage() {
                 src={
                   place.imageUrl
                     ? `http://localhost:8080${place.imageUrl}`
-                    : "/default-placeholder.jpg"
+                    : "/default-placeholder.svg"
                 }
                 alt={place.cityName}
                 className="w-full h-auto object-cover rounded-md cursor-pointer"

--- a/frontend/src/app/admin/place/ClientPage.tsx
+++ b/frontend/src/app/admin/place/ClientPage.tsx
@@ -73,49 +73,49 @@ export default function ClientPage() {
 
   return (
     <div>
+      <button className="mb-4 text-blue-500" onClick={() => router.back()}>
+        뒤로가기
+      </button>
       <h2 className="text-2xl font-bold mb-4">전체 여행지</h2>
+      <div className="flex items-center gap-4 mb-4">
+        <div className="flex gap-4 flex-grow">
+          <select
+            value={selectedCity}
+            onChange={(e) => setSelectedCity(e.target.value)}
+            className="p-2 border rounded-md"
+          >
+            <option value="">모든 도시</option>
+            {Array.from(new Set(places.map((place) => place.cityName))).map(
+              (city) => (
+                <option key={city} value={city}>
+                  {city}
+                </option>
+              )
+            )}
+          </select>
 
-      {/* Registration button for admin */}
-      <div className="mb-4">
+          <select
+            value={selectedCategory}
+            onChange={(e) => setSelectedCategory(e.target.value)}
+            className="p-2 border rounded-md"
+          >
+            <option value="">모든 카테고리</option>
+            {Array.from(new Set(places.map((place) => place.category))).map(
+              (category) => (
+                <option key={category} value={category}>
+                  {category}
+                </option>
+              )
+            )}
+          </select>
+        </div>
+
         <button
           className="bg-green-500 text-white px-4 py-2 rounded-md"
           onClick={() => router.push("/admin/place/create")}
         >
           여행지 등록
         </button>
-      </div>
-
-      {/* 여행지 필터링 UI */}
-      <div className="flex gap-4 mb-4">
-        <select
-          value={selectedCity}
-          onChange={(e) => setSelectedCity(e.target.value)}
-          className="p-2 border rounded-md"
-        >
-          <option value="">모든 도시</option>
-          {Array.from(new Set(places.map((place) => place.cityName))).map(
-            (city) => (
-              <option key={city} value={city}>
-                {city}
-              </option>
-            )
-          )}
-        </select>
-
-        <select
-          value={selectedCategory}
-          onChange={(e) => setSelectedCategory(e.target.value)}
-          className="p-2 border rounded-md"
-        >
-          <option value="">모든 카테고리</option>
-          {Array.from(new Set(places.map((place) => place.category))).map(
-            (category) => (
-              <option key={category} value={category}>
-                {category}
-              </option>
-            )
-          )}
-        </select>
       </div>
 
       {/* 여행지 리스트 */}

--- a/frontend/src/app/admin/place/ClientPage.tsx
+++ b/frontend/src/app/admin/place/ClientPage.tsx
@@ -48,13 +48,19 @@ export default function ClientPage() {
 
   const handleDelete = (id: number) => {
     if (!confirm("정말 삭제하시겠습니까?")) return;
+    // 관리자 토큰을 헤더에 포함하여 요청
+    const token = localStorage.getItem("accessToken");
     fetch(`http://localhost:8080/place/${id}`, {
       method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     })
       .then((res) => {
         if (!res.ok) {
           throw new Error("삭제에 실패했습니다.");
         }
+        // 삭제가 성공하면 state에서 해당 여행지를 제거합니다.
         setPlaces((prev) => prev.filter((place) => place.id !== id));
       })
       .catch((error) => console.error("Error deleting place:", error));

--- a/frontend/src/app/admin/place/ClientPage.tsx
+++ b/frontend/src/app/admin/place/ClientPage.tsx
@@ -23,6 +23,7 @@ export default function ClientPage() {
     fetch("http://localhost:8080/place")
       .then((res) => res.json())
       .then((data) => {
+        console.log("API Response:", data);
         if (data && data.data) {
           const mappedPlaces: Place[] = data.data.map((place: any) => ({
             id: place.id,
@@ -30,7 +31,7 @@ export default function ClientPage() {
             placeName: place.placeName,
             description: place.description,
             category: place.category,
-            imageUrl: place.imgeUrl,
+            imageUrl: place.imageUrl,
           }));
           setPlaces(mappedPlaces);
         }
@@ -128,7 +129,11 @@ export default function ClientPage() {
               className="bg-white rounded-lg shadow-md p-4 relative"
             >
               <img
-                src={place.imageUrl || "/default-placeholder.jpg"}
+                src={
+                  place.imageUrl
+                    ? `http://localhost:8080${place.imageUrl}`
+                    : "/default-placeholder.jpg"
+                }
                 alt={place.cityName}
                 className="w-full h-40 object-cover rounded-md cursor-pointer"
                 onClick={() => router.push(`/place/${place.id}`)}

--- a/frontend/src/app/admin/place/ClientPage.tsx
+++ b/frontend/src/app/admin/place/ClientPage.tsx
@@ -46,6 +46,20 @@ export default function ClientPage() {
       (!selectedCategory || place.category === selectedCategory)
   );
 
+  const handleDelete = (id: number) => {
+    if (!confirm("정말 삭제하시겠습니까?")) return;
+    fetch(`http://localhost:8080/place/${id}`, {
+      method: "DELETE",
+    })
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error("삭제에 실패했습니다.");
+        }
+        setPlaces((prev) => prev.filter((place) => place.id !== id));
+      })
+      .catch((error) => console.error("Error deleting place:", error));
+  };
+
   if (loading) {
     return <p>여행지 데이터를 불러오는 중...</p>;
   }
@@ -53,6 +67,16 @@ export default function ClientPage() {
   return (
     <div>
       <h2 className="text-2xl font-bold mb-4">전체 여행지</h2>
+
+      {/* Registration button for admin */}
+      <div className="mb-4">
+        <button
+          className="bg-green-500 text-white px-4 py-2 rounded-md"
+          onClick={() => router.push("/admin/place/create")}
+        >
+          여행지 등록
+        </button>
+      </div>
 
       {/* 여행지 필터링 UI */}
       <div className="flex gap-4 mb-4">
@@ -95,7 +119,7 @@ export default function ClientPage() {
           {filteredPlaces.map((place) => (
             <div
               key={place.id}
-              className="bg-white rounded-lg shadow-md p-4 cursor-pointer"
+              className="bg-white rounded-lg shadow-md p-4 relative"
             >
               <img
                 src={place.imageUrl || "/default-placeholder.jpg"}
@@ -110,6 +134,12 @@ export default function ClientPage() {
                 {place.placeName}
               </h3>
               <p className="text-gray-600">{place.description}</p>
+              <button
+                className="absolute top-2 right-2 bg-red-500 text-white px-2 py-1 rounded-md"
+                onClick={() => handleDelete(place.id)}
+              >
+                삭제
+              </button>
             </div>
           ))}
         </div>

--- a/frontend/src/app/admin/place/create/ClientPage.tsx
+++ b/frontend/src/app/admin/place/create/ClientPage.tsx
@@ -48,7 +48,7 @@ export default function CreatePlacePage() {
     formData.append("description", description);
     formData.append("category", category);
     if (imageFile) {
-      formData.append("image", imageFile);
+      formData.append("imageUrl", imageFile);
     }
 
     // FormData 내용 확인: 각 key, value 쌍 출력

--- a/frontend/src/app/admin/place/create/ClientPage.tsx
+++ b/frontend/src/app/admin/place/create/ClientPage.tsx
@@ -79,6 +79,9 @@ export default function CreatePlacePage() {
 
   return (
     <div className="max-w-xl mx-auto p-4">
+      <button className="mb-4 text-blue-500" onClick={() => router.back()}>
+        뒤로가기
+      </button>
       <h2 className="text-2xl font-bold mb-4">여행지 등록</h2>
       {error && <p className="text-red-500 mb-4">{error}</p>}
       <form onSubmit={handleSubmit} encType="multipart/form-data">

--- a/frontend/src/app/admin/place/create/ClientPage.tsx
+++ b/frontend/src/app/admin/place/create/ClientPage.tsx
@@ -51,6 +51,11 @@ export default function CreatePlacePage() {
       formData.append("image", imageFile);
     }
 
+    // FormData 내용 확인: 각 key, value 쌍 출력
+    for (let [key, value] of formData.entries()) {
+      console.log("키,값 : ", key, value);
+    }
+
     try {
       const res = await fetch("http://localhost:8080/place", {
         method: "POST",
@@ -104,13 +109,19 @@ export default function CreatePlacePage() {
         </div>
         <div className="mb-4">
           <label className="block text-gray-700">카테고리</label>
-          <input
-            type="text"
+          <select
             value={category}
             onChange={(e) => setCategory(e.target.value)}
             className="w-full p-2 border rounded-md"
             required
-          />
+          >
+            <option value="">카테고리 선택</option>
+            <option value="PLACE">장소</option>
+            <option value="STAY">숙소</option>
+            <option value="RESTAURANT">식당</option>
+            <option value="CAFE">카페</option>
+            <option value="ETC">기타</option>
+          </select>
         </div>
 
         {/* 단일 이미지 업로드 UI */}

--- a/frontend/src/app/admin/place/create/ClientPage.tsx
+++ b/frontend/src/app/admin/place/create/ClientPage.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Upload, X } from "lucide-react";
+
+export default function CreatePlacePage() {
+  const router = useRouter();
+  const [cityName, setCityName] = useState("");
+  const [placeName, setPlaceName] = useState("");
+  const [description, setDescription] = useState("");
+  const [category, setCategory] = useState("");
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [previewImage, setPreviewImage] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      const file = e.target.files[0];
+      setImageFile(file);
+      const preview = URL.createObjectURL(file);
+      setPreviewImage(preview);
+    }
+  };
+
+  const handleRemoveImage = () => {
+    if (previewImage) {
+      URL.revokeObjectURL(previewImage);
+    }
+    setImageFile(null);
+    setPreviewImage(null);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (previewImage) {
+        URL.revokeObjectURL(previewImage);
+      }
+    };
+  }, [previewImage]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const formData = new FormData();
+    formData.append("cityName", cityName);
+    formData.append("placeName", placeName);
+    formData.append("description", description);
+    formData.append("category", category);
+    if (imageFile) {
+      formData.append("image", imageFile);
+    }
+
+    try {
+      const res = await fetch("http://localhost:8080/place", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!res.ok) {
+        throw new Error("등록에 실패하였습니다.");
+      }
+      router.push("/admin/place");
+    } catch (err) {
+      console.error(err);
+      setError("여행지 등록 중 오류가 발생했습니다. 다시 시도해주세요.");
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <h2 className="text-2xl font-bold mb-4">여행지 등록</h2>
+      {error && <p className="text-red-500 mb-4">{error}</p>}
+      <form onSubmit={handleSubmit} encType="multipart/form-data">
+        <div className="mb-4">
+          <label className="block text-gray-700">도시 이름</label>
+          <input
+            type="text"
+            value={cityName}
+            onChange={(e) => setCityName(e.target.value)}
+            className="w-full p-2 border rounded-md"
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-gray-700">여행지 이름</label>
+          <input
+            type="text"
+            value={placeName}
+            onChange={(e) => setPlaceName(e.target.value)}
+            className="w-full p-2 border rounded-md"
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-gray-700">설명</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="w-full p-2 border rounded-md"
+            rows={4}
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-gray-700">카테고리</label>
+          <input
+            type="text"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            className="w-full p-2 border rounded-md"
+            required
+          />
+        </div>
+
+        {/* 단일 이미지 업로드 UI */}
+        <div className="mb-4">
+          <label className="block text-gray-700 mb-1">이미지</label>
+          <div className="mt-2">
+            <label className="flex justify-center items-center border-2 border-dashed border-gray-300 rounded-md p-6 cursor-pointer hover:bg-gray-50">
+              <div className="space-y-1 text-center">
+                <Upload className="mx-auto h-12 w-12 text-gray-400" />
+                <div className="text-sm text-gray-600">
+                  <span className="font-medium text-blue-600 hover:text-blue-500">
+                    파일 선택
+                  </span>{" "}
+                  또는 드래그 앤 드롭
+                </div>
+                <p className="text-xs text-gray-500">PNG, JPG, GIF 최대 10MB</p>
+              </div>
+              <input
+                type="file"
+                className="hidden"
+                accept="image/*"
+                onChange={handleImageUpload}
+              />
+            </label>
+          </div>
+          {previewImage && (
+            <div className="mt-4 relative">
+              <img
+                src={previewImage}
+                alt="Preview"
+                className="h-24 w-24 object-cover rounded-md"
+              />
+              <button
+                type="button"
+                onClick={handleRemoveImage}
+                className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full p-1"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          className="bg-blue-500 text-white px-4 py-2 rounded-md"
+        >
+          등록하기
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/place/create/ClientPage.tsx
+++ b/frontend/src/app/admin/place/create/ClientPage.tsx
@@ -57,8 +57,13 @@ export default function CreatePlacePage() {
     }
 
     try {
+      // 관리자 토큰을 헤더에 포함하여 요청
+      const token = localStorage.getItem("accessToken");
       const res = await fetch("http://localhost:8080/place", {
         method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
         body: formData,
       });
 

--- a/frontend/src/app/admin/place/create/page.tsx
+++ b/frontend/src/app/admin/place/create/page.tsx
@@ -1,0 +1,5 @@
+import ClientPage from "./ClientPage";
+
+export default async function Page() {
+  return <ClientPage />;
+}

--- a/frontend/src/app/admin/place/page.tsx
+++ b/frontend/src/app/admin/place/page.tsx
@@ -1,0 +1,5 @@
+import ClientPage from "./ClientPage";
+
+export default async function Page() {
+  return <ClientPage />;
+}

--- a/frontend/src/app/place/ClientPage.tsx
+++ b/frontend/src/app/place/ClientPage.tsx
@@ -30,7 +30,7 @@ export default function ClientPage() {
             placeName: place.placeName,
             description: place.description,
             category: place.category,
-            imageUrl: place.imgeUrl,
+            imageUrl: place.imageUrl,
           }));
           setPlaces(mappedPlaces);
         }
@@ -104,7 +104,7 @@ export default function ClientPage() {
                     : "/default-placeholder.jpg"
                 }
                 alt={place.cityName}
-                className="w-full h-40 object-cover rounded-md cursor-pointer"
+                className="w-full h-auto object-cover rounded-md cursor-pointer"
                 onClick={() => router.push(`/place/${place.id}`)}
               />
               <h3

--- a/frontend/src/app/place/ClientPage.tsx
+++ b/frontend/src/app/place/ClientPage.tsx
@@ -98,7 +98,11 @@ export default function ClientPage() {
               className="bg-white rounded-lg shadow-md p-4 cursor-pointer"
             >
               <img
-                src={place.imageUrl || "/default-placeholder.jpg"}
+                src={
+                  place.imageUrl
+                    ? `http://localhost:8080${place.imageUrl}`
+                    : "/default-placeholder.jpg"
+                }
                 alt={place.cityName}
                 className="w-full h-40 object-cover rounded-md cursor-pointer"
                 onClick={() => router.push(`/place/${place.id}`)}

--- a/frontend/src/app/place/ClientPage.tsx
+++ b/frontend/src/app/place/ClientPage.tsx
@@ -101,7 +101,7 @@ export default function ClientPage() {
                 src={
                   place.imageUrl
                     ? `http://localhost:8080${place.imageUrl}`
-                    : "/default-placeholder.jpg"
+                    : "/default-placeholder.svg"
                 }
                 alt={place.cityName}
                 className="w-full h-auto object-cover rounded-md cursor-pointer"

--- a/frontend/src/app/place/[id]/ClientPage.tsx
+++ b/frontend/src/app/place/[id]/ClientPage.tsx
@@ -51,7 +51,7 @@ export default function PlaceDetailPage() {
         src={
           place.imageUrl
             ? `http://localhost:8080${place.imageUrl}`
-            : "/default-placeholder.jpg"
+            : "/default-placeholder.svg"
         }
         alt={place.placeName}
         className="w-full h-auto object-cover rounded-md"

--- a/frontend/src/app/place/[id]/ClientPage.tsx
+++ b/frontend/src/app/place/[id]/ClientPage.tsx
@@ -10,7 +10,7 @@ interface Place {
   placeName: string;
   description: string;
   category: string;
-  image: string;
+  imageUrl: string;
 }
 
 export default function PlaceDetailPage() {
@@ -48,7 +48,7 @@ export default function PlaceDetailPage() {
       </button>
       <h1 className="text-3xl font-bold mb-4">{place.placeName}</h1>
       <img
-        src={place.image || "/default-placeholder.jpg"}
+        src={place.imageUrl || "/default-placeholder.jpg"}
         alt={place.placeName}
         className="w-full h-64 object-cover rounded-md"
       />

--- a/frontend/src/app/place/[id]/ClientPage.tsx
+++ b/frontend/src/app/place/[id]/ClientPage.tsx
@@ -54,7 +54,7 @@ export default function PlaceDetailPage() {
             : "/default-placeholder.jpg"
         }
         alt={place.placeName}
-        className="w-full h-64 object-cover rounded-md"
+        className="w-full h-auto object-cover rounded-md"
       />
       <p className="mt-4 text-gray-700">{place.description}</p>
       <p className="mt-2 text-sm text-gray-500">도시: {place.cityName}</p>

--- a/frontend/src/app/place/[id]/ClientPage.tsx
+++ b/frontend/src/app/place/[id]/ClientPage.tsx
@@ -48,7 +48,11 @@ export default function PlaceDetailPage() {
       </button>
       <h1 className="text-3xl font-bold mb-4">{place.placeName}</h1>
       <img
-        src={place.imageUrl || "/default-placeholder.jpg"}
+        src={
+          place.imageUrl
+            ? `http://localhost:8080${place.imageUrl}`
+            : "/default-placeholder.jpg"
+        }
         alt={place.placeName}
         className="w-full h-64 object-cover rounded-md"
       />


### PR DESCRIPTION
## 🔎 작업 내용

- 관리자 권한으로 여행지를 등록할 수 있다.
- 여행지 등록시 이미지를 등록할 수 있다.
- 관리자 권한으로 여행지를 삭제할 수 있다.
- 여행지의 세부 조회가 가능하다
- 여행지 조회시 이미지를 볼 수 있다.
- 기본 이미지 등록

  <br/>

## 이미지 첨부
- 여행지 전체 조회 화면
<img width="1359" alt="image" src="https://github.com/user-attachments/assets/654f2eb2-bdd4-4009-a506-e7ddcda11320" />

- 여행지 세부 조회 화면 
<img width="1359" alt="image" src="https://github.com/user-attachments/assets/0873ee27-472d-4d9b-8a8a-045252f25a27" />

- 여행지 관리 페이지 화면
<img width="737" alt="image" src="https://github.com/user-attachments/assets/1d68e92e-c9d3-4b91-8b67-d6a8cdfafeb3" />

- 여행지 등록 화면
<img width="737" alt="image" src="https://github.com/user-attachments/assets/615ca1fa-7fee-4a65-97ad-2e066361db72" />



<br/>

## ➕ 이슈 링크
- [GODAOS/feat-110-feat #110 ]

<br/>

<!-- closed #110  -->
